### PR TITLE
release: update LiteParse to 2.12.0

### DIFF
--- a/.feynman/runtime-package-lock.json
+++ b/.feynman/runtime-package-lock.json
@@ -2507,9 +2507,9 @@
       }
     },
     "node_modules/@llamaindex/liteparse": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.11.1.tgz",
-      "integrity": "sha512-VxTSYDYYrweAQ03Eq3G34TKu7kgVBmstIgbjF2pFaeA+loMoYjEQKvw5l89a9smWfT/F0aZSSl0yRICiCzUxVw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.12.0.tgz",
+      "integrity": "sha512-Tgay0LlZIAAuJVWYd7vIpaE46zJG4riYSB2v06eDZalF8bu1PJBHh4XtOYkod954TeuJA7ilJ/I/akkcWt4+mg==",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"
@@ -2522,19 +2522,19 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@llamaindex/liteparse-darwin-arm64": "2.11.1",
-        "@llamaindex/liteparse-darwin-x64": "2.11.1",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.11.1",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.11.1",
-        "@llamaindex/liteparse-linux-x64-musl": "2.11.1",
-        "@llamaindex/liteparse-win32-arm64-msvc": "2.11.1",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.11.1"
+        "@llamaindex/liteparse-darwin-arm64": "2.12.0",
+        "@llamaindex/liteparse-darwin-x64": "2.12.0",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.12.0",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.12.0",
+        "@llamaindex/liteparse-linux-x64-musl": "2.12.0",
+        "@llamaindex/liteparse-win32-arm64-msvc": "2.12.0",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.12.0"
       }
     },
     "node_modules/@llamaindex/liteparse-darwin-arm64": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.11.1.tgz",
-      "integrity": "sha512-5fKaGA94L8cmKYGMBpR/aaRSe2Cm26/t9gYeWG6A4SGRW2fymdGpdzsm0DAojQ1Muvd/AOsCiSkt3uTjDYcSvA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.12.0.tgz",
+      "integrity": "sha512-ELwUvAc8nmCKzcQ3cD+SSTgma4rvIF1Kgd7Yr5Cfle/qc04yyzGNvDyPKJz5sv2SipVmGugUSlx/UOuuK9ifcw==",
       "cpu": [
         "arm64"
       ],
@@ -2545,9 +2545,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-darwin-x64": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.11.1.tgz",
-      "integrity": "sha512-oXu6+hKpCRltLRXUcRqp1An4CncGZh5kHs0ZYhosHb/EZxWKAQnIyQMmkfQ5zBrb/CwzOwSHGN1p6Gnn7qiyRg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.12.0.tgz",
+      "integrity": "sha512-LBH+Tbm70PLnXQODDW0ljhVlEk+CJrRjc4eSb9t5ykZ6I029+AZ6LKkkeIiZy0bcweulpemyhOe6uN2bCV1PcA==",
       "cpu": [
         "x64"
       ],
@@ -2558,9 +2558,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-arm64-gnu": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.11.1.tgz",
-      "integrity": "sha512-WdndldwDNdGnj+35NhIGm0ENxt+pZuOdyzNRJl+u15qbkR3LmvXw8z3xotzrboCTScPErcDZv8eZYjwDNbAqMg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.12.0.tgz",
+      "integrity": "sha512-qMmhRXoqUDQmuo3Yn6X/P4OTkXcatN+DJa729uhnAj9UncSuLAkYRWfduD3cwlsVl0l0JMfPwFgUNz8+jjaJKg==",
       "cpu": [
         "arm64"
       ],
@@ -2574,9 +2574,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-gnu": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.11.1.tgz",
-      "integrity": "sha512-nZPj0g65wxmKK34OzfLYXTXMSTe74WxzfCmVnFsJR/WRAmnapmg6fcS9Oj5fjRLTnjGH7B4qpE2miUsJJkvRhw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.12.0.tgz",
+      "integrity": "sha512-ENG2K/JeRtAJaDTzuJvfmtOH2ENnorrAJ+3w4F6RzolvSQmNhOxPcYRrrpeXGM5ISi617yeBAli7EFhlu/qgqg==",
       "cpu": [
         "x64"
       ],
@@ -2590,9 +2590,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-musl": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.11.1.tgz",
-      "integrity": "sha512-uL/eVCivsOPDGOmmk2QC7hiEYOrer9VrzZMDz2OBxhOeNcnMNwtbRfntCNm0FMBOMkVO7W5T5bsfLiEkBsVz8g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.12.0.tgz",
+      "integrity": "sha512-sdXB7i1q/CStSeUHF5Q4P5YPya8uVIbwgAyZJNtBVk8PKv0H6jkhMFhhhzd1RpEskJJ21a9DZLBa3yKReYUM1A==",
       "cpu": [
         "x64"
       ],
@@ -2606,9 +2606,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-arm64-msvc": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.11.1.tgz",
-      "integrity": "sha512-n6XE9ugOxt3YnyfTNI2KV/Z4ul1ky+kY1DHchGRtfSKY5FiWX5wsdGGs8SNLqhjY3q9Ktz8kfzwqvKjpvZs3vQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.12.0.tgz",
+      "integrity": "sha512-4eNjYDPPFA5o/MIEOGLLhH3H7VQv+m6+EH4dgILXmHfDRSExBDvFm2jCwUBD7+yvx9MXZwkP0I0IXcBOFiDiNQ==",
       "cpu": [
         "arm64"
       ],
@@ -2619,9 +2619,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-x64-msvc": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.11.1.tgz",
-      "integrity": "sha512-gLSCPbP3CxUJfNGiZZ50Ct4piVilOSO4T2pL5Ca+SvB/RWvaLLjxjlFvr9ly6y04xSdvAUBUaMPdkHEcANPyqA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.12.0.tgz",
+      "integrity": "sha512-pF+p/x+fBwdFqOLeeSzDCUul0VOh6CM/LYE4+80TyqwWC/jTXkypXzeI4B9Vj7mC8WxNhR/EdHotrRxOvz2D4g==",
       "cpu": [
         "x64"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4368,3 +4368,10 @@ Use this file to track chronology, not release notes. Keep entries short, factua
 - Package proof: Dry and real packs matched at `121,036,187` bytes and `40,224` files. The real tarball SHA-256 is `a9eb0dea17141d1763bddd562ec69486751bd07738d625760772655bd85d13fd`; source/runtime/consumer audits and package, RPC, TypeBox, and document-parser verifiers passed.
 - Live proof: Local source and clean installed-tarball macOS runs returned `RESULT=PONG`; both configured an existing absolute researcher extension path and emitted no unavailable-child-tool diagnostic.
 - State: `unverified` for exact-head Daytona, pull-request CI, merge, and publication. Next: complete those gates and publish `0.3.18`.
+
+### 2026-08-13 05:55 CDT — liteparse-2.12.0-0.3.21
+
+- Objective: Adopt LiteParse `2.12.0` for the bundled document research runtime and qualify Feynman `0.3.21`.
+- Intake: Open issues, open PRs, active workflows, security advisories, and contributor port targets are empty. LiteParse `node-v2.12.0` resolves to upstream `2fd644a`; npm integrity and direct parse, page-count, screenshot, and batch probes passed.
+- Candidate: Updated the seven platform packages, runtime override and lock, artifact verifier, release notes, website release page, and focused tests. The candidate remains uncommitted and unpushed.
+- State: `unverified` for cumulative package checks, clean-machine proof, CI, merge, publication, and release identity. Next: run the full validation ladder, then persist the exact tested candidate.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,16 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.21 - 2026-08-13
+
+### Document research
+
+- Updated the bundled LiteParse runtime to `2.12.0`. Document parsing now handles large documents more reliably and fixes rotated-page edge clipping and Markdown inline-code escaping. The existing parse, search, and screenshot tools keep their current interface.
+
+### Validation
+
+- Re-ran the installed document parse, search, and screenshot flow against the bundled runtime.
+
 ## v0.3.20 - 2026-08-12
 
 ### Current research

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.20",
+      "version": "0.3.21",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",
@@ -24,13 +24,13 @@
         "@earendil-works/pi-ai": "0.84.1",
         "@earendil-works/pi-coding-agent": "0.84.1",
         "@earendil-works/pi-tui": "0.84.1",
-        "@llamaindex/liteparse-darwin-arm64": "2.11.1",
-        "@llamaindex/liteparse-darwin-x64": "2.11.1",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.11.1",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.11.1",
-        "@llamaindex/liteparse-linux-x64-musl": "2.11.1",
-        "@llamaindex/liteparse-win32-arm64-msvc": "2.11.1",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.11.1",
+        "@llamaindex/liteparse-darwin-arm64": "2.12.0",
+        "@llamaindex/liteparse-darwin-x64": "2.12.0",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.12.0",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.12.0",
+        "@llamaindex/liteparse-linux-x64-musl": "2.12.0",
+        "@llamaindex/liteparse-win32-arm64-msvc": "2.12.0",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.12.0",
         "@nightingale-elements/nightingale-msa": "^5.6.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.221.0",
@@ -83,13 +83,13 @@
         "node": ">=22.22.0 <26"
       },
       "optionalDependencies": {
-        "@llamaindex/liteparse-darwin-arm64": "2.11.1",
-        "@llamaindex/liteparse-darwin-x64": "2.11.1",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.11.1",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.11.1",
-        "@llamaindex/liteparse-linux-x64-musl": "2.11.1",
-        "@llamaindex/liteparse-win32-arm64-msvc": "2.11.1",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.11.1"
+        "@llamaindex/liteparse-darwin-arm64": "2.12.0",
+        "@llamaindex/liteparse-darwin-x64": "2.12.0",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.12.0",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.12.0",
+        "@llamaindex/liteparse-linux-x64-musl": "2.12.0",
+        "@llamaindex/liteparse-win32-arm64-msvc": "2.12.0",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.12.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -3937,9 +3937,9 @@
       }
     },
     "node_modules/@llamaindex/liteparse-darwin-arm64": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.11.1.tgz",
-      "integrity": "sha512-5fKaGA94L8cmKYGMBpR/aaRSe2Cm26/t9gYeWG6A4SGRW2fymdGpdzsm0DAojQ1Muvd/AOsCiSkt3uTjDYcSvA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.12.0.tgz",
+      "integrity": "sha512-ELwUvAc8nmCKzcQ3cD+SSTgma4rvIF1Kgd7Yr5Cfle/qc04yyzGNvDyPKJz5sv2SipVmGugUSlx/UOuuK9ifcw==",
       "cpu": [
         "arm64"
       ],
@@ -3950,9 +3950,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-darwin-x64": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.11.1.tgz",
-      "integrity": "sha512-oXu6+hKpCRltLRXUcRqp1An4CncGZh5kHs0ZYhosHb/EZxWKAQnIyQMmkfQ5zBrb/CwzOwSHGN1p6Gnn7qiyRg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.12.0.tgz",
+      "integrity": "sha512-LBH+Tbm70PLnXQODDW0ljhVlEk+CJrRjc4eSb9t5ykZ6I029+AZ6LKkkeIiZy0bcweulpemyhOe6uN2bCV1PcA==",
       "cpu": [
         "x64"
       ],
@@ -3963,9 +3963,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-arm64-gnu": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.11.1.tgz",
-      "integrity": "sha512-WdndldwDNdGnj+35NhIGm0ENxt+pZuOdyzNRJl+u15qbkR3LmvXw8z3xotzrboCTScPErcDZv8eZYjwDNbAqMg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.12.0.tgz",
+      "integrity": "sha512-qMmhRXoqUDQmuo3Yn6X/P4OTkXcatN+DJa729uhnAj9UncSuLAkYRWfduD3cwlsVl0l0JMfPwFgUNz8+jjaJKg==",
       "cpu": [
         "arm64"
       ],
@@ -3979,9 +3979,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-gnu": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.11.1.tgz",
-      "integrity": "sha512-nZPj0g65wxmKK34OzfLYXTXMSTe74WxzfCmVnFsJR/WRAmnapmg6fcS9Oj5fjRLTnjGH7B4qpE2miUsJJkvRhw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.12.0.tgz",
+      "integrity": "sha512-ENG2K/JeRtAJaDTzuJvfmtOH2ENnorrAJ+3w4F6RzolvSQmNhOxPcYRrrpeXGM5ISi617yeBAli7EFhlu/qgqg==",
       "cpu": [
         "x64"
       ],
@@ -3995,9 +3995,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-musl": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.11.1.tgz",
-      "integrity": "sha512-uL/eVCivsOPDGOmmk2QC7hiEYOrer9VrzZMDz2OBxhOeNcnMNwtbRfntCNm0FMBOMkVO7W5T5bsfLiEkBsVz8g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.12.0.tgz",
+      "integrity": "sha512-sdXB7i1q/CStSeUHF5Q4P5YPya8uVIbwgAyZJNtBVk8PKv0H6jkhMFhhhzd1RpEskJJ21a9DZLBa3yKReYUM1A==",
       "cpu": [
         "x64"
       ],
@@ -4011,9 +4011,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-arm64-msvc": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.11.1.tgz",
-      "integrity": "sha512-n6XE9ugOxt3YnyfTNI2KV/Z4ul1ky+kY1DHchGRtfSKY5FiWX5wsdGGs8SNLqhjY3q9Ktz8kfzwqvKjpvZs3vQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.12.0.tgz",
+      "integrity": "sha512-4eNjYDPPFA5o/MIEOGLLhH3H7VQv+m6+EH4dgILXmHfDRSExBDvFm2jCwUBD7+yvx9MXZwkP0I0IXcBOFiDiNQ==",
       "cpu": [
         "arm64"
       ],
@@ -4024,9 +4024,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-x64-msvc": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.11.1.tgz",
-      "integrity": "sha512-gLSCPbP3CxUJfNGiZZ50Ct4piVilOSO4T2pL5Ca+SvB/RWvaLLjxjlFvr9ly6y04xSdvAUBUaMPdkHEcANPyqA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.12.0.tgz",
+      "integrity": "sha512-pF+p/x+fBwdFqOLeeSzDCUul0VOh6CM/LYE4+80TyqwWC/jTXkypXzeI4B9Vj7mC8WxNhR/EdHotrRxOvz2D4g==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",
@@ -196,12 +196,12 @@
   },
   "author": "",
   "optionalDependencies": {
-    "@llamaindex/liteparse-darwin-arm64": "2.11.1",
-    "@llamaindex/liteparse-darwin-x64": "2.11.1",
-    "@llamaindex/liteparse-linux-arm64-gnu": "2.11.1",
-    "@llamaindex/liteparse-linux-x64-gnu": "2.11.1",
-    "@llamaindex/liteparse-linux-x64-musl": "2.11.1",
-    "@llamaindex/liteparse-win32-arm64-msvc": "2.11.1",
-    "@llamaindex/liteparse-win32-x64-msvc": "2.11.1"
+    "@llamaindex/liteparse-darwin-arm64": "2.12.0",
+    "@llamaindex/liteparse-darwin-x64": "2.12.0",
+    "@llamaindex/liteparse-linux-arm64-gnu": "2.12.0",
+    "@llamaindex/liteparse-linux-x64-gnu": "2.12.0",
+    "@llamaindex/liteparse-linux-x64-musl": "2.12.0",
+    "@llamaindex/liteparse-win32-arm64-msvc": "2.12.0",
+    "@llamaindex/liteparse-win32-x64-msvc": "2.12.0"
   }
 }

--- a/scripts/prepare-runtime-workspace.mjs
+++ b/scripts/prepare-runtime-workspace.mjs
@@ -87,7 +87,7 @@ const RUNTIME_PACKAGE_OVERRIDES = {
 	"@opentelemetry/sdk-node": "0.221.0",
 	"@opentelemetry/sdk-trace-base": "2.10.0",
 	"@opentelemetry/sdk-trace-node": "2.10.0",
-	"@llamaindex/liteparse": "2.11.1",
+	"@llamaindex/liteparse": "2.12.0",
 	"brace-expansion": "5.0.9",
 	"ip-address": "10.5.0",
 	undici: "8.10.0",

--- a/scripts/verify-package-artifact.mjs
+++ b/scripts/verify-package-artifact.mjs
@@ -28,8 +28,8 @@ const packageRoot = resolve(process.argv[2] ?? resolve(import.meta.dirname, ".."
 const packageRequire = createRequire(resolve(packageRoot, "package.json"));
 const FEYNMAN_BRACE_EXPANSION_VERSION = "5.0.9";
 const FEYNMAN_IP_ADDRESS_VERSION = "10.5.0";
-const FEYNMAN_LITEPARSE_VERSION = "2.11.1";
-const FEYNMAN_LITEPARSE_INTEGRITY = "sha512-VxTSYDYYrweAQ03Eq3G34TKu7kgVBmstIgbjF2pFaeA+loMoYjEQKvw5l89a9smWfT/F0aZSSl0yRICiCzUxVw==";
+const FEYNMAN_LITEPARSE_VERSION = "2.12.0";
+const FEYNMAN_LITEPARSE_INTEGRITY = "sha512-Tgay0LlZIAAuJVWYd7vIpaE46zJG4riYSB2v06eDZalF8bu1PJBHh4XtOYkod954TeuJA7ilJ/I/akkcWt4+mg==";
 const FEYNMAN_LITEPARSE_NATIVE_PACKAGES = [
 	"@llamaindex/liteparse-darwin-arm64",
 	"@llamaindex/liteparse-darwin-x64",

--- a/tests/package-seeding.test.ts
+++ b/tests/package-seeding.test.ts
@@ -67,7 +67,7 @@ test("prepare runtime workspace pins audited transitive runtime overrides", asyn
 	assert.match(runtimeWorkspaceSource, /"@mozilla\/readability": "0\.6\.0"/);
 	assert.match(runtimeWorkspaceSource, /"@opentelemetry\/sdk-node": "0\.221\.0"/);
 	assert.match(runtimeWorkspaceSource, /"@opentelemetry\/resources": "2\.10\.0"/);
-	assert.match(runtimeWorkspaceSource, /"@llamaindex\/liteparse": "2\.11\.1"/);
+	assert.match(runtimeWorkspaceSource, /"@llamaindex\/liteparse": "2\.12\.0"/);
 	assert.match(runtimeWorkspaceSource, /"ip-address": "10\.5\.0"/);
 	assert.match(runtimeWorkspaceSource, /undici: "8\.10\.0"/);
 	assert.match(runtimeWorkspaceSource, /"undici",\n\];/);
@@ -86,15 +86,15 @@ test("installed runtime scripts follow npm's platform-specific global prefix lay
 	}
 });
 
-test("0.3.12 release notes name the exact LiteParse runtime override", () => {
+test("0.3.21 release notes name the LiteParse runtime update", () => {
 	for (const path of [
 		resolve(process.cwd(), "RELEASES.md"),
 		resolve(process.cwd(), "website", "src", "content", "docs", "reference", "releases.md"),
 	]) {
 		const releases = readFileSync(path, "utf8");
-		const currentRelease = releases.match(/## v0\.3\.12[\s\S]*?(?=\n## v0\.3\.11)/)?.[0] ?? "";
-		assert.match(currentRelease, /LiteParse to `2\.11\.1`/);
-		assert.doesNotMatch(currentRelease, /LiteParse to `2\.11\.0`/);
+		const currentRelease = releases.match(/## v0\.3\.21[\s\S]*?(?=\n## v0\.3\.20)/)?.[0] ?? "";
+		assert.match(currentRelease, /bundled LiteParse runtime to `2\.12\.0`/);
+		assert.doesNotMatch(currentRelease, /LiteParse to `2\.11\.1`/);
 	}
 });
 
@@ -144,9 +144,9 @@ test("release manifests pin current document and website security repairs", () =
 		"@llamaindex/liteparse-win32-arm64-msvc",
 		"@llamaindex/liteparse-win32-x64-msvc",
 	]) {
-		assert.equal(manifest.optionalDependencies?.[packageName], "2.11.1");
-		assert.equal(lock.packages?.[""]?.optionalDependencies?.[packageName], "2.11.1");
-		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.version, "2.11.1");
+		assert.equal(manifest.optionalDependencies?.[packageName], "2.12.0");
+		assert.equal(lock.packages?.[""]?.optionalDependencies?.[packageName], "2.12.0");
+		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.version, "2.12.0");
 		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.optional, true);
 	}
 	assert.equal(websiteManifest.overrides?.["js-yaml"], "4.3.1");

--- a/tests/runtime-workspace-lock.test.ts
+++ b/tests/runtime-workspace-lock.test.ts
@@ -51,9 +51,9 @@ test("vendored runtime uses a committed exact dependency lock", () => {
 			integrity: (runtimeLock.packages["node_modules/@llamaindex/liteparse"] as { integrity?: string })?.integrity,
 		},
 		{
-			version: "2.11.1",
-			resolved: "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.11.1.tgz",
-			integrity: "sha512-VxTSYDYYrweAQ03Eq3G34TKu7kgVBmstIgbjF2pFaeA+loMoYjEQKvw5l89a9smWfT/F0aZSSl0yRICiCzUxVw==",
+			version: "2.12.0",
+			resolved: "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.12.0.tgz",
+			integrity: "sha512-Tgay0LlZIAAuJVWYd7vIpaE46zJG4riYSB2v06eDZalF8bu1PJBHh4XtOYkod954TeuJA7ilJ/I/akkcWt4+mg==",
 		},
 	);
 	assert.equal(runtimeLock.packages["node_modules/undici"]?.version, "8.10.0");

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,16 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.21 - 2026-08-13
+
+### Document research
+
+- Updated the bundled LiteParse runtime to `2.12.0`. Document parsing now handles large documents more reliably and fixes rotated-page edge clipping and Markdown inline-code escaping. The existing parse, search, and screenshot tools keep their current interface.
+
+### Validation
+
+- Re-ran the installed document parse, search, and screenshot flow against the bundled runtime.
+
 ## v0.3.20 - 2026-08-12
 
 ### Current research


### PR DESCRIPTION
## Summary

- update the bundled LiteParse runtime and all platform packages to `2.12.0`
- keep Feynman's existing document parse, search, and screenshot interface
- record the release and website documentation update

## Evidence

- LiteParse upstream tag `node-v2.12.0` resolves to `2fd644a9e10ceeee7379949a55fa77aaf26d4b9b`
- full Feynman tests pass: `783/783`
- clean installed tarball passes root and consumer audits, artifact verification, RPC/TypeBox loading, and installed `pi-docparser` parse/search/screenshot verification
- root and website production audits report zero vulnerabilities
