### PR TITLE
Fix GitHub Copilot login rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-15 09:38 EDT — pi-copilot-rate-limit-0.3.23
+
+- Objective: Port Pi's merged GitHub Copilot login fixes into the current `0.84.2` runtime and qualify Feynman `0.3.23`.
+- Intake: Open Feynman issues and pull requests remain empty. No issue or PR changed after the prior automation cutoff. The 30 newest forks are behind or equal to `main` except `NioZow/feynman`, whose old Nix packaging commit remains rejected. Security alert and advisory queues are empty.
+- Fixed: Applied upstream Pi commits `d5278ea` and `086c32e` to every root, nested, vendored, and agent-managed Pi AI runtime copy. Copilot policy updates now run sequentially, and model discovery honors `Retry-After` before one bounded retry.
+- Fixed: Consolidated embedded Pi AI target discovery after the first full test found `scripts/patch-embedded-pi.mjs` above the architecture limit. The script is now `1,170` lines without weakening the guard.
+- Verified: Focused patch tests passed (`9/9`), and the full suite passed (`784/784`). Typecheck, build, architecture, website lint/typecheck/build (`34` pages), root/website/runtime audits, package freshness review, and diff checks passed. The mocked Copilot login proved one active policy request and a successful second model request after `429`.
+- Package proof: Dry and real packs matched at `114,755,955` bytes and `29,134` files. The tarball SHA-256 is `0c7db229e9cd6d1ae45fd80319f0d82311196c3a77cb65c3d64fdc365ca78728`; clean source/runtime/consumer audits and package, stale-upgrade, 15-tool/9-command RPC, TypeBox, Copilot, and document parse/search/screenshot verifiers passed.
+- State: `unverified` for exact-commit Daytona, PR CI, merge, publication, and post-release identity. Next: finish those gates, then publish and verify `0.3.23`.
+
 ### 2026-08-15 06:32 EDT — intake-sweep-v0-3-22-daytona-proof
 
 - Objective: Complete clean-machine proof for the published Feynman `0.3.22` release and close the intake sweep.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To uninstall the standalone app, remove the launcher and runtime bundle, then op
 
 Local models are supported through the setup flow. For LM Studio, run `feynman setup`, choose `LM Studio`, and keep the default `http://localhost:1234/v1` unless you changed the server port. For LiteLLM, choose `LiteLLM Proxy` and keep the default `http://localhost:4000/v1`. For Ollama or vLLM, choose `Custom provider (baseUrl + API key)`, use `openai-completions`, and point it at the local `/v1` endpoint.
 
-To authenticate another hosted provider, run `feynman model login <provider>`. OpenRouter login opens an OAuth page and listens for a local callback; over SSH or in another headless environment, paste the browser's final redirect URL or authorization code into Feynman's prompt, or set `OPENROUTER_API_KEY` before launch to use API-key authentication without OAuth.
+To authenticate another hosted provider, run `feynman model login <provider>`. GitHub Copilot sign-in retries model discovery once when GitHub rate-limits the request. OpenRouter login opens an OAuth page and listens for a local callback; over SSH or in another headless environment, paste the browser's final redirect URL or authorization code into Feynman's prompt, or set `OPENROUTER_API_KEY` before launch to use API-key authentication without OAuth.
 
 ### Skills Only
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,17 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.23 - 2026-08-15
+
+### Provider login reliability
+
+- GitHub Copilot sign-in now enables model policies sequentially instead of sending a burst of parallel requests.
+- If Copilot rate-limits model discovery, Feynman honors `Retry-After` and retries once instead of ending sign-in.
+
+### Validation
+
+- Added exact source, packaged-runtime, and login regressions for the Copilot rate-limit path.
+
 ## v0.3.22 - 2026-08-14
 
 ### Web research

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.22",
+      "version": "0.3.23",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/scripts/lib/pi-runtime-correctness-patch.d.mts
+++ b/scripts/lib/pi-runtime-correctness-patch.d.mts
@@ -7,18 +7,29 @@ export declare const PI_RUNTIME_CORRECTNESS_PATCH_MARKERS: Readonly<{
 	agentSession: string;
 	sessionManager: string;
 	transformMessages: string;
+	githubCopilotDeviceCode: string;
+	githubCopilotOAuth: string;
 }>;
 export declare const PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS: Readonly<{
 	agentSession: readonly string[];
 	sessionManager: readonly string[];
 	transformMessages: readonly string[];
+	githubCopilotDeviceCode: readonly string[];
+	githubCopilotOAuth: readonly string[];
 }>;
 export declare function assertPiRuntimeCorrectnessVersion(version: string | undefined, surface: string): void;
 export declare function assertPiRuntimeCorrectnessPatchSource(
 	source: string,
-	target: "agentSession" | "sessionManager" | "transformMessages",
+	target:
+		| "agentSession"
+		| "sessionManager"
+		| "transformMessages"
+		| "githubCopilotDeviceCode"
+		| "githubCopilotOAuth",
 	surface?: string,
 ): void;
 export declare function patchPiAgentSessionSource(source: string): string;
 export declare function patchPiSessionManagerSource(source: string): string;
 export declare function patchPiTransformMessagesSource(source: string): string;
+export declare function patchPiGithubCopilotDeviceCodeSource(source: string): string;
+export declare function patchPiGithubCopilotOAuthSource(source: string): string;

--- a/scripts/lib/pi-runtime-correctness-patch.mjs
+++ b/scripts/lib/pi-runtime-correctness-patch.mjs
@@ -1,23 +1,30 @@
 /**
  * Temporary Pi 0.84.2 correctness patches for:
  * - https://github.com/earendil-works/pi/issues/7053
+ * - https://github.com/earendil-works/pi/issues/8121
  *
  * Removal condition: delete this patch once a supported released Pi version
  * eagerly persists finalized parallel tool results while restoring them in
- * tool-call order.
+ * tool-call order and includes upstream commits d5278ea and 086c32e.
  */
 export const PI_RUNTIME_CORRECTNESS_PATCH_TARGETS = Object.freeze({
 	codingAgent: Object.freeze([
 		"dist/core/agent-session.js",
 		"dist/core/session-manager.js",
 	]),
-	piAi: Object.freeze(["dist/api/transform-messages.js"]),
+	piAi: Object.freeze([
+		"dist/api/transform-messages.js",
+		"dist/auth/oauth/device-code.js",
+		"dist/auth/oauth/github-copilot.js",
+	]),
 });
 export const PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION = "0.84.2";
 export const PI_RUNTIME_CORRECTNESS_PATCH_MARKERS = Object.freeze({
 	agentSession: "Feynman Pi 0.84.2 correctness patch: issue #7053",
 	sessionManager: "Feynman Pi 0.84.2 correctness patch: restore eager tool results",
 	transformMessages: "Feynman Pi 0.84.2 correctness patch: order eager tool results",
+	githubCopilotDeviceCode: "Feynman Pi 0.84.2 correctness patch: export abortableSleep for upstream #8121",
+	githubCopilotOAuth: "Feynman Pi 0.84.2 correctness patch: upstream #8121",
 });
 export const PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS = Object.freeze({
 	agentSession: Object.freeze([
@@ -55,6 +62,23 @@ export const PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS = Object.freeze({
     flushFeynmanToolResults();
 `,
 	]),
+	githubCopilotDeviceCode: Object.freeze([
+		PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.githubCopilotDeviceCode,
+		"export function abortableSleep(ms, signal, cancelMessage) {",
+	]),
+	githubCopilotOAuth: Object.freeze([
+		PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.githubCopilotOAuth,
+		'import { abortableSleep, pollOAuthDeviceCodeFlow } from "./device-code.js";',
+		"const MAX_RETRY_AFTER_MS = 10_000;",
+		"const DEFAULT_RETRY_AFTER_MS = 1_000;",
+		"const request = () =>",
+		"if (response.status === 429) {",
+		'response.headers.get("retry-after")',
+		'await abortableSleep(waitMs, signal, "Login cancelled");',
+		"return parseAvailableCopilotModelIds(await response.json(), allowPolicyFallback);",
+		"for (const model of Object.values(GITHUB_COPILOT_MODELS)) {",
+		"await enableGitHubCopilotModel(token, model.id, enterpriseDomain, signal);",
+	]),
 });
 
 const PI_RUNTIME_CORRECTNESS_ORDERED_FRAGMENTS = Object.freeze({
@@ -73,11 +97,26 @@ const PI_RUNTIME_CORRECTNESS_ORDERED_FRAGMENTS = Object.freeze({
 		"const flushFeynmanToolResults = () => {",
 		"pendingToolResults.set(msg.toolCallId, msg);",
 	]),
+	githubCopilotDeviceCode: Object.freeze([
+		PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.githubCopilotDeviceCode,
+		"export function abortableSleep(ms, signal, cancelMessage) {",
+	]),
+	githubCopilotOAuth: Object.freeze([
+		PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.githubCopilotOAuth,
+		"const request = () =>",
+		"if (response.status === 429) {",
+		'await abortableSleep(waitMs, signal, "Login cancelled");',
+		"for (const model of Object.values(GITHUB_COPILOT_MODELS)) {",
+	]),
 });
 
 const AGENT_SESSION_MARKER = PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.agentSession;
 const SESSION_MANAGER_MARKER = PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.sessionManager;
 const TRANSFORM_MESSAGES_MARKER = PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.transformMessages;
+const GITHUB_COPILOT_DEVICE_CODE_MARKER =
+	PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.githubCopilotDeviceCode;
+const GITHUB_COPILOT_OAUTH_MARKER =
+	PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.githubCopilotOAuth;
 
 export function assertPiRuntimeCorrectnessVersion(version, surface) {
 	if (version !== PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION) {
@@ -517,5 +556,123 @@ export function patchPiTransformMessagesSource(source) {
 		"transform-messages second pass",
 	);
 	assertPiRuntimeCorrectnessPatchSource(patched, "transformMessages");
+	return patched;
+}
+
+const ORIGINAL_COPILOT_MODEL_FETCH = `    const raw = await fetchJson(\`\${baseUrl}/models\`, {
+        headers: {
+            Accept: "application/json",
+            Authorization: \`Bearer \${copilotToken}\`,
+            ...COPILOT_HEADERS,
+            "X-GitHub-Api-Version": COPILOT_API_VERSION,
+        },
+        signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]),
+    });
+    return parseAvailableCopilotModelIds(raw, allowPolicyFallback);`;
+
+const PATCHED_COPILOT_MODEL_FETCH = `    const request = () =>
+        fetch(\`\${baseUrl}/models\`, {
+            headers: {
+                Accept: "application/json",
+                Authorization: \`Bearer \${copilotToken}\`,
+                ...COPILOT_HEADERS,
+                "X-GitHub-Api-Version": COPILOT_API_VERSION,
+            },
+            signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]),
+        });
+    // The login-time policy updates can drain the Copilot API rate-limit bucket, in which case
+    // this request is rejected with 429. Honor Retry-After and retry once instead of failing.
+    let response = await request();
+    if (response.status === 429) {
+        const retryAfterSeconds = Number(response.headers.get("retry-after"));
+        const waitMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+            ? Math.min(retryAfterSeconds * 1000, MAX_RETRY_AFTER_MS)
+            : DEFAULT_RETRY_AFTER_MS;
+        await abortableSleep(waitMs, signal, "Login cancelled");
+        response = await request();
+    }
+    if (!response.ok) {
+        const text = await response.text();
+        throw new Error(\`\${response.status} \${response.statusText}: \${text}\`);
+    }
+    return parseAvailableCopilotModelIds(await response.json(), allowPolicyFallback);`;
+
+const ORIGINAL_COPILOT_POLICY_UPDATES = `    const models = Object.values(GITHUB_COPILOT_MODELS);
+    for (let index = 0; index < models.length; index += COPILOT_POLICY_CONCURRENCY) {
+        await Promise.all(models.slice(index, index + COPILOT_POLICY_CONCURRENCY).map(async (model) => {
+            await enableGitHubCopilotModel(token, model.id, enterpriseDomain, signal);
+        }));
+    }`;
+
+const PATCHED_COPILOT_POLICY_UPDATES = `    for (const model of Object.values(GITHUB_COPILOT_MODELS)) {
+        await enableGitHubCopilotModel(token, model.id, enterpriseDomain, signal);
+    }`;
+
+export function patchPiGithubCopilotDeviceCodeSource(source) {
+	if (source.includes(GITHUB_COPILOT_DEVICE_CODE_MARKER)) {
+		assertPiRuntimeCorrectnessPatchSource(
+			source,
+			"githubCopilotDeviceCode",
+		"github-copilot device-code",
+		);
+		return source;
+	}
+	const patched = replaceRequired(
+		source,
+		"function abortableSleep(ms, signal, cancelMessage) {",
+		`// ${GITHUB_COPILOT_DEVICE_CODE_MARKER}
+export function abortableSleep(ms, signal, cancelMessage) {`,
+		"github-copilot device-code export",
+	);
+	assertPiRuntimeCorrectnessPatchSource(
+		patched,
+		"githubCopilotDeviceCode",
+		"github-copilot device-code",
+	);
+	return patched;
+}
+
+export function patchPiGithubCopilotOAuthSource(source) {
+	if (source.includes(GITHUB_COPILOT_OAUTH_MARKER)) {
+		assertPiRuntimeCorrectnessPatchSource(
+			source,
+			"githubCopilotOAuth",
+			"github-copilot OAuth",
+		);
+		return source;
+	}
+	let patched = replaceRequired(
+		source,
+		'import { pollOAuthDeviceCodeFlow } from "./device-code.js";',
+		'import { abortableSleep, pollOAuthDeviceCodeFlow } from "./device-code.js";',
+		"github-copilot OAuth import",
+	);
+	patched = replaceRequired(
+		patched,
+		`const COPILOT_API_VERSION = "2026-06-01";
+const COPILOT_POLICY_CONCURRENCY = 4;`,
+		`const COPILOT_API_VERSION = "2026-06-01";
+// ${GITHUB_COPILOT_OAUTH_MARKER}
+const MAX_RETRY_AFTER_MS = 10_000;
+const DEFAULT_RETRY_AFTER_MS = 1_000;`,
+		"github-copilot OAuth limits",
+	);
+	patched = replaceRequired(
+		patched,
+		ORIGINAL_COPILOT_MODEL_FETCH,
+		PATCHED_COPILOT_MODEL_FETCH,
+		"github-copilot model discovery",
+	);
+	patched = replaceRequired(
+		patched,
+		ORIGINAL_COPILOT_POLICY_UPDATES,
+		PATCHED_COPILOT_POLICY_UPDATES,
+		"github-copilot policy updates",
+	);
+	assertPiRuntimeCorrectnessPatchSource(
+		patched,
+		"githubCopilotOAuth",
+		"github-copilot OAuth",
+	);
 	return patched;
 }

--- a/scripts/patch-embedded-pi.mjs
+++ b/scripts/patch-embedded-pi.mjs
@@ -13,6 +13,8 @@ import {
 	assertPiRuntimeCorrectnessVersion,
 	PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION,
 	patchPiAgentSessionSource,
+	patchPiGithubCopilotDeviceCodeSource,
+	patchPiGithubCopilotOAuthSource,
 	patchPiSessionManagerSource,
 	patchPiTransformMessagesSource,
 } from "./lib/pi-runtime-correctness-patch.mjs";
@@ -123,10 +125,6 @@ const sessionManagerPath = piPackageRoot ? resolve(piPackageRoot, "dist", "core"
 const llamaProviderPath = piPackageRoot
 	? resolve(piPackageRoot, "dist", "extensions", "llama", "provider.js")
 	: null;
-const transformMessagesPath = piAiRoot ? resolve(piAiRoot, "dist", "api", "transform-messages.js") : null;
-const nestedTransformMessagesPaths = piPackageRoot
-	? resolveNestedPiFiles(piPackageRoot, "pi-ai", "dist", "api", "transform-messages.js")
-	: [];
 const agentLoopPath = piAgentCoreRoot ? resolve(piAgentCoreRoot, "dist", "agent-loop.js") : null;
 const nestedAgentLoopPaths = resolveNestedPiFiles(piPackageRoot, "pi-agent-core", "dist", "agent-loop.js");
 const tuiPath = piTuiRoot ? resolve(piTuiRoot, "dist", "tui.js") : null;
@@ -145,6 +143,28 @@ function resolveWorkspacePiFile(packageName, ...segments) {
 	return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
 }
 
+function resolvePiAiRuntimeFiles(...segments) {
+	return [
+		piAiRoot ? resolve(piAiRoot, ...segments) : null,
+		...resolveNestedPiFiles(piPackageRoot, "pi-ai", ...segments),
+		resolveWorkspacePiFile("pi-ai", ...segments),
+		...resolveWorkspaceNestedPiFiles(workspaceRoot, "pi-ai", ...segments),
+	].filter(Boolean);
+}
+
+const transformMessagesPaths = resolvePiAiRuntimeFiles("dist", "api", "transform-messages.js");
+const githubCopilotDeviceCodePaths = resolvePiAiRuntimeFiles(
+	"dist",
+	"auth",
+	"oauth",
+	"device-code.js",
+);
+const githubCopilotOAuthPaths = resolvePiAiRuntimeFiles(
+	"dist",
+	"auth",
+	"oauth",
+	"github-copilot.js",
+);
 const workspaceAgentLoopPath = resolveWorkspacePiFile("pi-agent-core", "dist", "agent-loop.js");
 const workspaceNestedAgentLoopPaths = resolveWorkspaceNestedPiFiles(
 	workspaceRoot,
@@ -160,14 +180,6 @@ const workspaceLlamaProviderPath = resolveWorkspacePiFile(
 	"extensions",
 	"llama",
 	"provider.js",
-);
-const workspaceTransformMessagesPath = resolveWorkspacePiFile("pi-ai", "dist", "api", "transform-messages.js");
-const workspaceNestedTransformMessagesPaths = resolveWorkspaceNestedPiFiles(
-	workspaceRoot,
-	"pi-ai",
-	"dist",
-	"api",
-	"transform-messages.js",
 );
 
 function assertPiPackageVersion(packageRoot, surface) {
@@ -201,8 +213,8 @@ assertPiPackageVersion(piTuiRoot, "bundled pi-tui");
 for (const entryPath of nestedAgentLoopPaths) {
 	assertPiPackageVersion(resolve(entryPath, "..", ".."), "bundled nested pi-agent-core");
 }
-for (const entryPath of nestedTransformMessagesPaths) {
-	assertPiPackageVersion(resolve(entryPath, "..", "..", ".."), "bundled nested pi-ai");
+for (const entryPath of transformMessagesPaths) {
+	assertPiPackageVersion(resolve(entryPath, "..", "..", ".."), "Pi AI runtime package");
 }
 for (const entryPath of nestedTuiPaths) {
 	assertPiPackageVersion(resolve(entryPath, "..", ".."), "bundled nested pi-tui");
@@ -971,10 +983,15 @@ for (const [entryPath, patchSource] of [
 	[workspaceAgentSessionPath, patchPiAgentSessionSource],
 	[sessionManagerPath, patchPiSessionManagerSource],
 	[workspaceSessionManagerPath, patchPiSessionManagerSource],
-	[transformMessagesPath, patchPiTransformMessagesSource],
-	[workspaceTransformMessagesPath, patchPiTransformMessagesSource],
-	...nestedTransformMessagesPaths.map((entryPath) => [entryPath, patchPiTransformMessagesSource]),
-	...workspaceNestedTransformMessagesPaths.map((entryPath) => [entryPath, patchPiTransformMessagesSource]),
+	...transformMessagesPaths.map((entryPath) => [entryPath, patchPiTransformMessagesSource]),
+	...githubCopilotDeviceCodePaths.map((entryPath) => [
+		entryPath,
+		patchPiGithubCopilotDeviceCodeSource,
+	]),
+	...githubCopilotOAuthPaths.map((entryPath) => [
+		entryPath,
+		patchPiGithubCopilotOAuthSource,
+	]),
 ]) {
 	if (
 		!entryPath ||

--- a/scripts/prepare-runtime-workspace.mjs
+++ b/scripts/prepare-runtime-workspace.mjs
@@ -7,6 +7,8 @@ import {
 	assertPiRuntimeCorrectnessVersion,
 	PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION,
 	patchPiAgentSessionSource,
+	patchPiGithubCopilotDeviceCodeSource,
+	patchPiGithubCopilotOAuthSource,
 	patchPiSessionManagerSource,
 	patchPiTransformMessagesSource,
 } from "./lib/pi-runtime-correctness-patch.mjs";
@@ -479,7 +481,7 @@ function patchBundledPiAgentCore() {
 	return changed;
 }
 
-function patchBundledNestedPiAiTransformMessages() {
+function patchBundledNestedPiAiFile(relativePath, patchSource) {
 	let changed = false;
 	for (const codingScope of ["@earendil-works", "@mariozechner"]) {
 		for (const aiScope of ["@earendil-works", "@mariozechner"]) {
@@ -490,13 +492,11 @@ function patchBundledNestedPiAiTransformMessages() {
 				"node_modules",
 				aiScope,
 				"pi-ai",
-				"dist",
-				"api",
-				"transform-messages.js",
+				...relativePath.split("/"),
 			);
 			if (!existsSync(filePath)) continue;
 			const source = readFileSync(filePath, "utf8");
-			const patched = patchPiTransformMessagesSource(source);
+			const patched = patchSource(source);
 			if (patched === source) continue;
 			writeFileSync(filePath, patched, "utf8");
 			changed = true;
@@ -545,7 +545,28 @@ function patchBundledPiRuntimeCorrectness() {
 		"dist/api/transform-messages.js",
 		patchPiTransformMessagesSource,
 	) || changed;
-	changed = patchBundledNestedPiAiTransformMessages() || changed;
+	changed = patchBundledNestedPiAiFile(
+		"dist/api/transform-messages.js",
+		patchPiTransformMessagesSource,
+	) || changed;
+	changed = patchScopedPiWorkspaceFile(
+		"pi-ai",
+		"dist/auth/oauth/device-code.js",
+		patchPiGithubCopilotDeviceCodeSource,
+	) || changed;
+	changed = patchBundledNestedPiAiFile(
+		"dist/auth/oauth/device-code.js",
+		patchPiGithubCopilotDeviceCodeSource,
+	) || changed;
+	changed = patchScopedPiWorkspaceFile(
+		"pi-ai",
+		"dist/auth/oauth/github-copilot.js",
+		patchPiGithubCopilotOAuthSource,
+	) || changed;
+	changed = patchBundledNestedPiAiFile(
+		"dist/auth/oauth/github-copilot.js",
+		patchPiGithubCopilotOAuthSource,
+	) || changed;
 	return changed;
 }
 

--- a/scripts/verify-installed-runtime.mjs
+++ b/scripts/verify-installed-runtime.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
 	createAgentSession,
@@ -627,10 +627,95 @@ export async function verifyInstalledSchemas() {
 	}
 }
 
+export async function verifyGithubCopilotRateLimitLogin() {
+	const copilotModulePath = resolve(
+		packageRoot,
+		"node_modules",
+		"@earendil-works",
+		"pi-ai",
+		"dist",
+		"auth",
+		"oauth",
+		"github-copilot.js",
+	);
+	assert.ok(existsSync(copilotModulePath), "Installed GitHub Copilot OAuth module is missing");
+	const originalFetch = globalThis.fetch;
+	let activePolicyRequests = 0;
+	let maxActivePolicyRequests = 0;
+	let policyRequestCount = 0;
+	let modelsRequestCount = 0;
+	globalThis.fetch = async (input) => {
+		const url = typeof input === "string" || input instanceof URL
+			? String(input)
+			: input.url;
+		if (url.endsWith("/login/device/code")) {
+			return Response.json({
+				device_code: "device-code",
+				user_code: "ABCD-EFGH",
+				verification_uri: "https://github.com/login/device",
+				interval: 1,
+				expires_in: 30,
+			});
+		}
+		if (url.endsWith("/login/oauth/access_token")) {
+			return Response.json({ access_token: "ghu_refresh_token" });
+		}
+		if (url.includes("/copilot_internal/v2/token")) {
+			return Response.json({
+				token: "tid=test;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;",
+				expires_at: 9_999_999_999,
+			});
+		}
+		if (url.includes("/models/") && url.endsWith("/policy")) {
+			policyRequestCount += 1;
+			activePolicyRequests += 1;
+			maxActivePolicyRequests = Math.max(maxActivePolicyRequests, activePolicyRequests);
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 1));
+			activePolicyRequests -= 1;
+			return new Response("", { status: 200 });
+		}
+		if (url.endsWith("/models")) {
+			modelsRequestCount += 1;
+			if (modelsRequestCount === 1) {
+				return new Response("too many requests", {
+					status: 429,
+					headers: { "retry-after": "0.001" },
+				});
+			}
+			return Response.json({
+				data: [{ id: "gpt-5.4", model_picker_enabled: true }],
+			});
+		}
+		throw new Error(`Unexpected GitHub Copilot request: ${url}`);
+	};
+
+	try {
+		const copilotModule = await import(
+			`${pathToFileURL(copilotModulePath).href}?installed-verifier=${Date.now()}`
+		);
+		const credentials = await copilotModule.githubCopilotOAuth.login({
+			prompt: async () => "",
+			notify: () => {},
+			signal: new AbortController().signal,
+		});
+		assert.ok(policyRequestCount > 1, "Copilot login did not enable model policies");
+		assert.equal(
+			maxActivePolicyRequests,
+			1,
+			"Copilot login sent concurrent policy requests",
+		);
+		assert.equal(modelsRequestCount, 2, "Copilot model discovery did not retry exactly once");
+		assert.deepEqual(credentials.availableModelIds, ["gpt-5.4"]);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
 async function main() {
 	await verifyRpcSurface();
 	await verifyWebAccessRegistrationGates();
 	await verifyInstalledSchemas();
+	await verifyGithubCopilotRateLimitLogin();
 	console.log(JSON.stringify({
 		binary: defaultBinaryPath,
 		commands: EXPECTED_FEYNMAN_COMMANDS.length,
@@ -640,6 +725,7 @@ async function main() {
 		typeboxOptionalNull: "omitted",
 		typeboxMalformedArguments: "rejected",
 		webAccessRegistrationGates: "passed",
+		githubCopilotRateLimit: "passed",
 	}));
 }
 

--- a/scripts/verify-package-artifact.mjs
+++ b/scripts/verify-package-artifact.mjs
@@ -189,6 +189,8 @@ requireMarkers(
 		"valid-typebox-probe",
 		"null-typebox-probe",
 		"invalid-typebox-probe",
+		"verifyGithubCopilotRateLimitLogin",
+		'githubCopilotRateLimit: "passed"',
 		"terminateChildProcessTree",
 	],
 );
@@ -275,6 +277,32 @@ for (const [label, path] of [
 	],
 ]) {
 	assertPiRuntimeCorrectnessPatchSource(readText(path, label), "transformMessages", label);
+}
+for (const [target, relativePath] of [
+	["githubCopilotDeviceCode", "dist/auth/oauth/device-code.js"],
+	["githubCopilotOAuth", "dist/auth/oauth/github-copilot.js"],
+]) {
+	for (const [label, path] of [
+		[
+			`bundled root Pi AI ${target}`,
+			resolve(packageRoot, "node_modules", "@earendil-works", "pi-ai", ...relativePath.split("/")),
+		],
+		[
+			`bundled nested Pi AI ${target}`,
+			resolve(
+				packageRoot,
+				"node_modules",
+				"@earendil-works",
+				"pi-coding-agent",
+				"node_modules",
+				"@earendil-works",
+				"pi-ai",
+				...relativePath.split("/"),
+			),
+		],
+	]) {
+		assertPiRuntimeCorrectnessPatchSource(readText(path, label), target, label);
+	}
 }
 if (
 	readJson(
@@ -636,6 +664,27 @@ for (const [label, entryPath] of [
 		"transformMessages",
 		label,
 	);
+}
+for (const [target, relativePath] of [
+	["githubCopilotDeviceCode", "dist/auth/oauth/device-code.js"],
+	["githubCopilotOAuth", "dist/auth/oauth/github-copilot.js"],
+]) {
+	for (const [label, entryPath] of [
+		[
+			`runtime root Pi AI ${target}`,
+			`npm/node_modules/@earendil-works/pi-ai/${relativePath}`,
+		],
+		[
+			`runtime nested Pi AI ${target}`,
+			`npm/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/${relativePath}`,
+		],
+	]) {
+		assertPiRuntimeCorrectnessPatchSource(
+			readArchivedText(archivePath, entryPath),
+			target,
+			label,
+		);
+	}
 }
 for (const [label, entryPath] of [
 	[

--- a/src/pi/runtime-patches.ts
+++ b/src/pi/runtime-patches.ts
@@ -8,6 +8,8 @@ import { patchPiAgentCoreSource } from "../../scripts/lib/pi-agent-core-patch.mj
 import {
 	assertPiRuntimeCorrectnessVersion,
 	patchPiAgentSessionSource,
+	patchPiGithubCopilotDeviceCodeSource,
+	patchPiGithubCopilotOAuthSource,
 	patchPiSessionManagerSource,
 	patchPiTransformMessagesSource,
 } from "../../scripts/lib/pi-runtime-correctness-patch.mjs";
@@ -278,6 +280,36 @@ export function patchPiRuntimeNodeModules(
 			"pi-ai",
 			"dist/api/transform-messages.js",
 			patchPiTransformMessagesSource,
+			bundledPiVersion,
+		) || changed;
+		changed = patchScopedPiPackageFileIfPresent(
+			nodeModulesPath,
+			"pi-ai",
+			"dist/auth/oauth/device-code.js",
+			patchPiGithubCopilotDeviceCodeSource,
+			bundledPiVersion,
+		) || changed;
+		changed = patchNestedPiPackageFileIfPresent(
+			nodeModulesPath,
+			"pi-coding-agent",
+			"pi-ai",
+			"dist/auth/oauth/device-code.js",
+			patchPiGithubCopilotDeviceCodeSource,
+			bundledPiVersion,
+		) || changed;
+		changed = patchScopedPiPackageFileIfPresent(
+			nodeModulesPath,
+			"pi-ai",
+			"dist/auth/oauth/github-copilot.js",
+			patchPiGithubCopilotOAuthSource,
+			bundledPiVersion,
+		) || changed;
+		changed = patchNestedPiPackageFileIfPresent(
+			nodeModulesPath,
+			"pi-coding-agent",
+			"pi-ai",
+			"dist/auth/oauth/github-copilot.js",
+			patchPiGithubCopilotOAuthSource,
 			bundledPiVersion,
 		) || changed;
 		changed = patchScopedPiPackageFileIfPresent(

--- a/tests/pi-runtime-correctness-patch.test.ts
+++ b/tests/pi-runtime-correctness-patch.test.ts
@@ -14,6 +14,8 @@ import {
 	PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS,
 	PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION,
 	patchPiAgentSessionSource,
+	patchPiGithubCopilotDeviceCodeSource,
+	patchPiGithubCopilotOAuthSource,
 	patchPiSessionManagerSource,
 	patchPiTransformMessagesSource,
 } from "../scripts/lib/pi-runtime-correctness-patch.mjs";
@@ -61,6 +63,52 @@ const nestedTransformMessagesPath = resolve(
 	"api",
 	"transform-messages.js",
 );
+const githubCopilotDeviceCodePath = resolve(
+	appRoot,
+	"node_modules",
+	"@earendil-works",
+	"pi-ai",
+	"dist",
+	"auth",
+	"oauth",
+	"device-code.js",
+);
+const githubCopilotOAuthPath = resolve(
+	appRoot,
+	"node_modules",
+	"@earendil-works",
+	"pi-ai",
+	"dist",
+	"auth",
+	"oauth",
+	"github-copilot.js",
+);
+const nestedGithubCopilotDeviceCodePath = resolve(
+	appRoot,
+	"node_modules",
+	"@earendil-works",
+	"pi-coding-agent",
+	"node_modules",
+	"@earendil-works",
+	"pi-ai",
+	"dist",
+	"auth",
+	"oauth",
+	"device-code.js",
+);
+const nestedGithubCopilotOAuthPath = resolve(
+	appRoot,
+	"node_modules",
+	"@earendil-works",
+	"pi-coding-agent",
+	"node_modules",
+	"@earendil-works",
+	"pi-ai",
+	"dist",
+	"auth",
+	"oauth",
+	"github-copilot.js",
+);
 
 function createResourceLoader(runtime: unknown) {
 	return {
@@ -85,6 +133,16 @@ test("Pi 0.84.2 correctness patch is applied, idempotent, and documents its remo
 	const sessionManagerSource = readFileSync(sessionManagerPath, "utf8");
 	const transformMessagesSource = readFileSync(transformMessagesPath, "utf8");
 	const nestedTransformMessagesSource = readFileSync(nestedTransformMessagesPath, "utf8");
+	const githubCopilotDeviceCodeSource = readFileSync(githubCopilotDeviceCodePath, "utf8");
+	const githubCopilotOAuthSource = readFileSync(githubCopilotOAuthPath, "utf8");
+	const nestedGithubCopilotDeviceCodeSource = readFileSync(
+		nestedGithubCopilotDeviceCodePath,
+		"utf8",
+	);
+	const nestedGithubCopilotOAuthSource = readFileSync(
+		nestedGithubCopilotOAuthPath,
+		"utf8",
+	);
 	const patchSource = readFileSync(
 		resolve(appRoot, "scripts", "lib", "pi-runtime-correctness-patch.mjs"),
 		"utf8",
@@ -102,16 +160,49 @@ test("Pi 0.84.2 correctness patch is applied, idempotent, and documents its remo
 	assert.match(transformMessagesSource, /flushFeynmanToolResults/);
 	assert.match(nestedTransformMessagesSource, /order eager tool results/);
 	assert.match(nestedTransformMessagesSource, /flushFeynmanToolResults/);
+	for (const source of [
+		githubCopilotDeviceCodeSource,
+		nestedGithubCopilotDeviceCodeSource,
+	]) {
+		assert.match(source, /export abortableSleep for upstream #8121/);
+		assert.match(source, /export function abortableSleep/);
+	}
+	for (const source of [githubCopilotOAuthSource, nestedGithubCopilotOAuthSource]) {
+		assert.match(source, /upstream #8121/);
+		assert.match(source, /response\.status === 429/);
+		assert.match(source, /response\.headers\.get\("retry-after"\)/);
+		assert.match(source, /for \(const model of Object\.values\(GITHUB_COPILOT_MODELS\)\)/);
+		assert.doesNotMatch(source, /COPILOT_POLICY_CONCURRENCY/);
+	}
 	assert.match(patchSource, /Removal condition: delete this patch once a supported released Pi version/);
+	assert.match(patchSource, /upstream commits d5278ea and 086c32e/);
 
 	assert.equal(patchPiAgentSessionSource(agentSessionSource), agentSessionSource);
 	assert.equal(patchPiSessionManagerSource(sessionManagerSource), sessionManagerSource);
 	assert.equal(patchPiTransformMessagesSource(transformMessagesSource), transformMessagesSource);
 	assert.equal(patchPiTransformMessagesSource(nestedTransformMessagesSource), nestedTransformMessagesSource);
+	assert.equal(
+		patchPiGithubCopilotDeviceCodeSource(githubCopilotDeviceCodeSource),
+		githubCopilotDeviceCodeSource,
+	);
+	assert.equal(
+		patchPiGithubCopilotDeviceCodeSource(nestedGithubCopilotDeviceCodeSource),
+		nestedGithubCopilotDeviceCodeSource,
+	);
+	assert.equal(
+		patchPiGithubCopilotOAuthSource(githubCopilotOAuthSource),
+		githubCopilotOAuthSource,
+	);
+	assert.equal(
+		patchPiGithubCopilotOAuthSource(nestedGithubCopilotOAuthSource),
+		nestedGithubCopilotOAuthSource,
+	);
 	for (const [target, source] of [
 		["agentSession", agentSessionSource],
 		["sessionManager", sessionManagerSource],
 		["transformMessages", transformMessagesSource],
+		["githubCopilotDeviceCode", githubCopilotDeviceCodeSource],
+		["githubCopilotOAuth", githubCopilotOAuthSource],
 	] as const) {
 		assert.doesNotThrow(() => assertPiRuntimeCorrectnessPatchSource(source, target));
 		for (const fragment of PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS[target]) {
@@ -135,6 +226,14 @@ test("Pi 0.84.2 correctness patch is applied, idempotent, and documents its remo
 		() => patchPiAgentSessionSource("export class AgentSession {}\n"),
 		/Unsupported Pi 0\.84\.2 agent-session import layout/,
 	);
+	assert.throws(
+		() => patchPiGithubCopilotDeviceCodeSource("function sleep() {}\n"),
+		/Unsupported Pi 0\.84\.2 github-copilot device-code export layout/,
+	);
+	assert.throws(
+		() => patchPiGithubCopilotOAuthSource("export const githubCopilotOAuth = {};\n"),
+		/Unsupported Pi 0\.84\.2 github-copilot OAuth import layout/,
+	);
 	assert.doesNotThrow(() =>
 		assertPiRuntimeCorrectnessVersion(PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION, "test"),
 	);
@@ -146,6 +245,81 @@ test("Pi 0.84.2 correctness patch is applied, idempotent, and documents its remo
 		() => assertPiRuntimeCorrectnessVersion("0.84.0", "test"),
 		/expected 0\.84\.2, found 0\.84\.0/,
 	);
+});
+
+test("GitHub Copilot login serializes policy updates and retries model discovery after 429", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let activePolicyRequests = 0;
+	let maxActivePolicyRequests = 0;
+	let policyRequestCount = 0;
+	let modelsRequestCount = 0;
+	globalThis.fetch = async (input) => {
+		const url = typeof input === "string" || input instanceof URL
+			? String(input)
+			: input.url;
+		if (url.endsWith("/login/device/code")) {
+			return Response.json({
+				device_code: "device-code",
+				user_code: "ABCD-EFGH",
+				verification_uri: "https://github.com/login/device",
+				interval: 1,
+				expires_in: 30,
+			});
+		}
+		if (url.endsWith("/login/oauth/access_token")) {
+			return Response.json({ access_token: "ghu_refresh_token" });
+		}
+		if (url.includes("/copilot_internal/v2/token")) {
+			return Response.json({
+				token: "tid=test;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;",
+				expires_at: 9_999_999_999,
+			});
+		}
+		if (url.includes("/models/") && url.endsWith("/policy")) {
+			policyRequestCount += 1;
+			activePolicyRequests += 1;
+			maxActivePolicyRequests = Math.max(maxActivePolicyRequests, activePolicyRequests);
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 1));
+			activePolicyRequests -= 1;
+			return new Response("", { status: 200 });
+		}
+		if (url.endsWith("/models")) {
+			modelsRequestCount += 1;
+			if (modelsRequestCount === 1) {
+				return new Response("too many requests", {
+					status: 429,
+					headers: { "retry-after": "0.001" },
+				});
+			}
+			return Response.json({
+				data: [{ id: "gpt-5.4", model_picker_enabled: true }],
+			});
+		}
+		throw new Error(`Unexpected GitHub Copilot request: ${url}`);
+	};
+
+	const copilotModule = await import(`${pathToFileURL(githubCopilotOAuthPath).href}?test=${Date.now()}`) as {
+		githubCopilotOAuth: {
+			login: (interaction: {
+				prompt: () => Promise<string>;
+				notify: (event: unknown) => void;
+				signal: AbortSignal;
+			}) => Promise<{ availableModelIds?: string[] }>;
+		};
+	};
+	const credentials = await copilotModule.githubCopilotOAuth.login({
+		prompt: async () => "",
+		notify: () => {},
+		signal: new AbortController().signal,
+	});
+
+	assert.ok(policyRequestCount > 1);
+	assert.equal(maxActivePolicyRequests, 1);
+	assert.equal(modelsRequestCount, 2);
+	assert.deepEqual(credentials.availableModelIds, ["gpt-5.4"]);
 });
 
 test("Pi 0.84.2 correctness patch migrates the pre-review eager persistence layout", () => {

--- a/website/src/content/docs/getting-started/setup.md
+++ b/website/src/content/docs/getting-started/setup.md
@@ -29,7 +29,7 @@ The non-premium model you choose here becomes the default for all sessions. You 
 
 ## Stage 2: Authentication
 
-Depending on your chosen provider, setup prompts you for an API key or walks you through OAuth login. For providers that support Pi OAuth (like Anthropic, OpenAI, and OpenRouter), Feynman opens a browser window to complete the sign-in flow. In a remote or headless OpenRouter session where the loopback callback is unavailable, paste the browser's final redirect URL or authorization code into Feynman's prompt. You can also set `OPENROUTER_API_KEY` before launching Feynman to use an OpenRouter API key without OAuth. Stored credentials live in the Pi auth storage at `~/.feynman/`.
+Depending on your chosen provider, setup prompts you for an API key or walks you through OAuth login. For providers that support Pi OAuth, such as Anthropic, OpenAI, GitHub Copilot, and OpenRouter, Feynman opens a browser window to complete sign-in. GitHub Copilot sign-in retries model discovery once when GitHub rate-limits the request. In a remote or headless OpenRouter session where the loopback callback is unavailable, paste the browser's final redirect URL or authorization code into Feynman's prompt. You can also set `OPENROUTER_API_KEY` before launching Feynman to use an OpenRouter API key without OAuth. Stored credentials live in the Pi auth storage at `~/.feynman/`.
 
 For API key providers, you are prompted to paste your key directly:
 

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,17 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.23 - 2026-08-15
+
+### Provider login reliability
+
+- GitHub Copilot sign-in now enables model policies sequentially instead of sending a burst of parallel requests.
+- If Copilot rate-limits model discovery, Feynman honors `Retry-After` and retries once instead of ending sign-in.
+
+### Validation
+
+- Added exact source, packaged-runtime, and login regressions for the Copilot rate-limit path.
+
 ## v0.3.22 - 2026-08-14
 
 ### Web research


### PR DESCRIPTION
## Summary

- port upstream Pi commits `d5278ea` and `086c32e` onto bundled Pi `0.84.2`
- serialize Copilot model-policy updates and retry model discovery once after `429`
- patch and verify root, nested, vendored, and agent-managed Pi AI copies
- publish the user-visible fix as Feynman `0.3.23`

Upstream issue: https://github.com/earendil-works/pi/issues/8121

## Validation

- focused patch tests: `9/9`
- full tests: `784/784`
- typecheck, build, architecture check, and `git diff --check`
- website lint, typecheck, and 34-page build
- root, website, runtime, clean-consumer, and extracted-runtime production audits: zero vulnerabilities
- dry and real local pack: `114,755,955` bytes, `29,134` files, SHA-256 `0c7db229e9cd6d1ae45fd80319f0d82311196c3a77cb65c3d64fdc365ca78728`
- clean installed consumer: package artifact, stale-Pi repair, 15 tools, 9 commands, TypeBox, Copilot `429`, and document parse/search/screenshot verifiers passed
- Daytona exact-head proof at `9a01d52f7ddbdfaf5e6d0e953f013449ca45f077`: `784/784`, complete cumulative ladder, clean checkout, SHA-256 `a343fc186fb174ec6fb21da596920355ac0860ec309dbbabc8426c88bb32c97e`
