### PR TITLE
release: update LiteParse to 2.13.0

### DIFF
--- a/.feynman/runtime-package-lock.json
+++ b/.feynman/runtime-package-lock.json
@@ -169,13 +169,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz",
-      "integrity": "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -381,13 +381,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz",
-      "integrity": "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2455,9 +2455,9 @@
       }
     },
     "node_modules/@llamaindex/liteparse": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.12.0.tgz",
-      "integrity": "sha512-Tgay0LlZIAAuJVWYd7vIpaE46zJG4riYSB2v06eDZalF8bu1PJBHh4XtOYkod954TeuJA7ilJ/I/akkcWt4+mg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.13.0.tgz",
+      "integrity": "sha512-Gbe9oBrllB7R81R80ztZoYvJnxHx1n9ggl+idpq1Nb8LRz95tYb1dDVGeH02JbJPgCl6ewK3V9HMIb4FbXGu0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"
@@ -2470,19 +2470,19 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@llamaindex/liteparse-darwin-arm64": "2.12.0",
-        "@llamaindex/liteparse-darwin-x64": "2.12.0",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.12.0",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.12.0",
-        "@llamaindex/liteparse-linux-x64-musl": "2.12.0",
-        "@llamaindex/liteparse-win32-arm64-msvc": "2.12.0",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.12.0"
+        "@llamaindex/liteparse-darwin-arm64": "2.13.0",
+        "@llamaindex/liteparse-darwin-x64": "2.13.0",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.13.0",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.13.0",
+        "@llamaindex/liteparse-linux-x64-musl": "2.13.0",
+        "@llamaindex/liteparse-win32-arm64-msvc": "2.13.0",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.13.0"
       }
     },
     "node_modules/@llamaindex/liteparse-darwin-arm64": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.12.0.tgz",
-      "integrity": "sha512-ELwUvAc8nmCKzcQ3cD+SSTgma4rvIF1Kgd7Yr5Cfle/qc04yyzGNvDyPKJz5sv2SipVmGugUSlx/UOuuK9ifcw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.13.0.tgz",
+      "integrity": "sha512-m5u24zyn5NNdPz4Tl7Hp7riEUqsLYBKsS6blgW+KYzo1hr4QbfR5K9oA5T0R1XPKGsNv3vqbwtkdxJpSSeH8MA==",
       "cpu": [
         "arm64"
       ],
@@ -2493,9 +2493,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-darwin-x64": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.12.0.tgz",
-      "integrity": "sha512-LBH+Tbm70PLnXQODDW0ljhVlEk+CJrRjc4eSb9t5ykZ6I029+AZ6LKkkeIiZy0bcweulpemyhOe6uN2bCV1PcA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.13.0.tgz",
+      "integrity": "sha512-u7rOvbGn8ofGjBBKalYB1JSdTpQATEvEOnCYM/8PhNMfBkpDZxfTyxpese0IMa2kp9i6QghNHxtTyl0gOhQFLA==",
       "cpu": [
         "x64"
       ],
@@ -2506,9 +2506,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-arm64-gnu": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.12.0.tgz",
-      "integrity": "sha512-qMmhRXoqUDQmuo3Yn6X/P4OTkXcatN+DJa729uhnAj9UncSuLAkYRWfduD3cwlsVl0l0JMfPwFgUNz8+jjaJKg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.13.0.tgz",
+      "integrity": "sha512-cpyOhwYY2UGvQ0zlKNUuLnAyVZP0+GpoGaM6asnPmV42yv6noDWTWhhmfi25DsECK+k12frKuCwinUSAziidTw==",
       "cpu": [
         "arm64"
       ],
@@ -2522,9 +2522,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-gnu": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.12.0.tgz",
-      "integrity": "sha512-ENG2K/JeRtAJaDTzuJvfmtOH2ENnorrAJ+3w4F6RzolvSQmNhOxPcYRrrpeXGM5ISi617yeBAli7EFhlu/qgqg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.13.0.tgz",
+      "integrity": "sha512-smigviGSoOdm+0wh2w7flWMiFWS64V/A7DxlnQIuCsBf9S41ElSJfFSLGttDwBj1h9TQTa1tEnUPe0jeF/Mnbw==",
       "cpu": [
         "x64"
       ],
@@ -2538,9 +2538,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-musl": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.12.0.tgz",
-      "integrity": "sha512-sdXB7i1q/CStSeUHF5Q4P5YPya8uVIbwgAyZJNtBVk8PKv0H6jkhMFhhhzd1RpEskJJ21a9DZLBa3yKReYUM1A==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.13.0.tgz",
+      "integrity": "sha512-GQF/iNiVtXT1rMZ4LzYD5l4mWGd4P7CuZ03QooKlOGbqD4pHLhdHAxt9YjEe7AYgLo9iJBj6lGoovNGu70hSUQ==",
       "cpu": [
         "x64"
       ],
@@ -2554,9 +2554,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-arm64-msvc": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.12.0.tgz",
-      "integrity": "sha512-4eNjYDPPFA5o/MIEOGLLhH3H7VQv+m6+EH4dgILXmHfDRSExBDvFm2jCwUBD7+yvx9MXZwkP0I0IXcBOFiDiNQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.13.0.tgz",
+      "integrity": "sha512-XtsIn1jgpY0k6yVgU2KYVNBnyaszFCe+5OBVBAkQCJcqMrUik2GYh//zaTNmknDLai5rTTa4hGdIy23lK5zLeg==",
       "cpu": [
         "arm64"
       ],
@@ -2567,9 +2567,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-x64-msvc": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.12.0.tgz",
-      "integrity": "sha512-pF+p/x+fBwdFqOLeeSzDCUul0VOh6CM/LYE4+80TyqwWC/jTXkypXzeI4B9Vj7mC8WxNhR/EdHotrRxOvz2D4g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.13.0.tgz",
+      "integrity": "sha512-gspSELWFZJ3aYfnkBH/9+TeHM2XyqKjRCiNPJVi03StWt3BZ+EMkunTyEwUZQEpjm2vH0uhKTK9hRFPegKMLcg==",
       "cpu": [
         "x64"
       ],
@@ -3202,12 +3202,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@smithy/core": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.0.tgz",
-      "integrity": "sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg==",
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.17.0",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3215,13 +3215,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
-      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3229,13 +3229,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
-      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3269,13 +3269,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
-      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3283,9 +3283,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
-      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5237,9 +5237,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-15 17:56 EDT — liteparse-2.13.0-0.3.24
+
+- Objective: Qualify the new LiteParse `2.13.0` document research runtime and carry the update toward release.
+- Intake: GitHub issues, pull requests, active workflows, Dependabot alerts, repository advisories, and code-scanning analyses are empty. The 30 newest forks are behind `main` except `NioZow/feynman`, which has one old generic Nix packaging commit and remains rejected.
+- Upstream: LiteParse `node-v2.13.0` (`36e7431`) adds mixed-font garbled-text detection and layout-block output. The change improves paper reading and extraction, so it fits Feynman's research-runtime scope.
+- Candidate: Bumped Feynman to `0.3.24`, updated all seven native LiteParse packages, the runtime override and lock, artifact gates, release notes, and website release notes. The runtime archive resolves LiteParse `2.13.0`; the generated lock also refreshed current AWS Smithy and Jose patch versions.
+- Verified: `784/784` tests, typecheck, build, architecture check, website lint/typecheck/build (`34` pages), root and website production audits, diff check, package verifier, dry/real packs, clean consumer audits, installed runtime and document verifiers, CLI smoke, and a direct `extractBlocks` probe passed. The pack is `114,842,276` bytes, `29,140` files, SHA-256 `1523c00e0b446942303499e0aab366b1c7dd33ef6b12fa0a9e9957e3cbf62545`.
+- State: `unverified` for the exact committed SHA, Daytona proof, pull-request CI, merge, publication, and post-release identity. The nested dirty `website` checkout and existing ignored research artifacts remain preserved.
+- Next: Commit the candidate, run exact-head Daytona and GitHub gates, then merge and publish `0.3.24` if all release checks remain green.
+
 ### 2026-08-15 13:36 EDT — intake-sweep-0.3.23-post-release
 
 - Objective: Refresh the complete Feynman AI-researcher intake after the `0.3.23` release and persist the verified state.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,16 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.24 - 2026-08-15
+
+### Document research
+
+- Updated the bundled LiteParse runtime to `2.13.0`. Document parsing now improves garbled-text detection for mixed-font papers and uses layout-aware block classification for richer structured extraction. The existing parse, search, and screenshot tools keep their current interface.
+
+### Validation
+
+- Re-ran the installed document parse, search, and screenshot flow against the bundled runtime.
+
 ## v0.3.23 - 2026-08-15
 
 ### Provider login reliability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",
@@ -76,13 +76,13 @@
         "node": ">=22.22.0 <26"
       },
       "optionalDependencies": {
-        "@llamaindex/liteparse-darwin-arm64": "2.12.0",
-        "@llamaindex/liteparse-darwin-x64": "2.12.0",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.12.0",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.12.0",
-        "@llamaindex/liteparse-linux-x64-musl": "2.12.0",
-        "@llamaindex/liteparse-win32-arm64-msvc": "2.12.0",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.12.0"
+        "@llamaindex/liteparse-darwin-arm64": "2.13.0",
+        "@llamaindex/liteparse-darwin-x64": "2.13.0",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.13.0",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.13.0",
+        "@llamaindex/liteparse-linux-x64-musl": "2.13.0",
+        "@llamaindex/liteparse-win32-arm64-msvc": "2.13.0",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.13.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -2676,11 +2676,11 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
       "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
-      },
-      "inBundle": true
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
       "version": "6.21.0",
@@ -3874,9 +3874,9 @@
       }
     },
     "node_modules/@llamaindex/liteparse-darwin-arm64": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.12.0.tgz",
-      "integrity": "sha512-ELwUvAc8nmCKzcQ3cD+SSTgma4rvIF1Kgd7Yr5Cfle/qc04yyzGNvDyPKJz5sv2SipVmGugUSlx/UOuuK9ifcw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.13.0.tgz",
+      "integrity": "sha512-m5u24zyn5NNdPz4Tl7Hp7riEUqsLYBKsS6blgW+KYzo1hr4QbfR5K9oA5T0R1XPKGsNv3vqbwtkdxJpSSeH8MA==",
       "cpu": [
         "arm64"
       ],
@@ -3887,9 +3887,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-darwin-x64": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.12.0.tgz",
-      "integrity": "sha512-LBH+Tbm70PLnXQODDW0ljhVlEk+CJrRjc4eSb9t5ykZ6I029+AZ6LKkkeIiZy0bcweulpemyhOe6uN2bCV1PcA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.13.0.tgz",
+      "integrity": "sha512-u7rOvbGn8ofGjBBKalYB1JSdTpQATEvEOnCYM/8PhNMfBkpDZxfTyxpese0IMa2kp9i6QghNHxtTyl0gOhQFLA==",
       "cpu": [
         "x64"
       ],
@@ -3900,9 +3900,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-arm64-gnu": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.12.0.tgz",
-      "integrity": "sha512-qMmhRXoqUDQmuo3Yn6X/P4OTkXcatN+DJa729uhnAj9UncSuLAkYRWfduD3cwlsVl0l0JMfPwFgUNz8+jjaJKg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.13.0.tgz",
+      "integrity": "sha512-cpyOhwYY2UGvQ0zlKNUuLnAyVZP0+GpoGaM6asnPmV42yv6noDWTWhhmfi25DsECK+k12frKuCwinUSAziidTw==",
       "cpu": [
         "arm64"
       ],
@@ -3916,9 +3916,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-gnu": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.12.0.tgz",
-      "integrity": "sha512-ENG2K/JeRtAJaDTzuJvfmtOH2ENnorrAJ+3w4F6RzolvSQmNhOxPcYRrrpeXGM5ISi617yeBAli7EFhlu/qgqg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.13.0.tgz",
+      "integrity": "sha512-smigviGSoOdm+0wh2w7flWMiFWS64V/A7DxlnQIuCsBf9S41ElSJfFSLGttDwBj1h9TQTa1tEnUPe0jeF/Mnbw==",
       "cpu": [
         "x64"
       ],
@@ -3932,9 +3932,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-musl": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.12.0.tgz",
-      "integrity": "sha512-sdXB7i1q/CStSeUHF5Q4P5YPya8uVIbwgAyZJNtBVk8PKv0H6jkhMFhhhzd1RpEskJJ21a9DZLBa3yKReYUM1A==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.13.0.tgz",
+      "integrity": "sha512-GQF/iNiVtXT1rMZ4LzYD5l4mWGd4P7CuZ03QooKlOGbqD4pHLhdHAxt9YjEe7AYgLo9iJBj6lGoovNGu70hSUQ==",
       "cpu": [
         "x64"
       ],
@@ -3948,9 +3948,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-arm64-msvc": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.12.0.tgz",
-      "integrity": "sha512-4eNjYDPPFA5o/MIEOGLLhH3H7VQv+m6+EH4dgILXmHfDRSExBDvFm2jCwUBD7+yvx9MXZwkP0I0IXcBOFiDiNQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.13.0.tgz",
+      "integrity": "sha512-XtsIn1jgpY0k6yVgU2KYVNBnyaszFCe+5OBVBAkQCJcqMrUik2GYh//zaTNmknDLai5rTTa4hGdIy23lK5zLeg==",
       "cpu": [
         "arm64"
       ],
@@ -3961,9 +3961,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-x64-msvc": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.12.0.tgz",
-      "integrity": "sha512-pF+p/x+fBwdFqOLeeSzDCUul0VOh6CM/LYE4+80TyqwWC/jTXkypXzeI4B9Vj7mC8WxNhR/EdHotrRxOvz2D4g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.13.0.tgz",
+      "integrity": "sha512-gspSELWFZJ3aYfnkBH/9+TeHM2XyqKjRCiNPJVi03StWt3BZ+EMkunTyEwUZQEpjm2vH0uhKTK9hRFPegKMLcg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",
@@ -196,12 +196,12 @@
   },
   "author": "",
   "optionalDependencies": {
-    "@llamaindex/liteparse-darwin-arm64": "2.12.0",
-    "@llamaindex/liteparse-darwin-x64": "2.12.0",
-    "@llamaindex/liteparse-linux-arm64-gnu": "2.12.0",
-    "@llamaindex/liteparse-linux-x64-gnu": "2.12.0",
-    "@llamaindex/liteparse-linux-x64-musl": "2.12.0",
-    "@llamaindex/liteparse-win32-arm64-msvc": "2.12.0",
-    "@llamaindex/liteparse-win32-x64-msvc": "2.12.0"
+    "@llamaindex/liteparse-darwin-arm64": "2.13.0",
+    "@llamaindex/liteparse-darwin-x64": "2.13.0",
+    "@llamaindex/liteparse-linux-arm64-gnu": "2.13.0",
+    "@llamaindex/liteparse-linux-x64-gnu": "2.13.0",
+    "@llamaindex/liteparse-linux-x64-musl": "2.13.0",
+    "@llamaindex/liteparse-win32-arm64-msvc": "2.13.0",
+    "@llamaindex/liteparse-win32-x64-msvc": "2.13.0"
   }
 }

--- a/scripts/prepare-runtime-workspace.mjs
+++ b/scripts/prepare-runtime-workspace.mjs
@@ -89,7 +89,7 @@ const RUNTIME_PACKAGE_OVERRIDES = {
 	"@opentelemetry/sdk-node": "0.221.0",
 	"@opentelemetry/sdk-trace-base": "2.10.0",
 	"@opentelemetry/sdk-trace-node": "2.10.0",
-	"@llamaindex/liteparse": "2.12.0",
+	"@llamaindex/liteparse": "2.13.0",
 	"brace-expansion": "5.0.9",
 	"ip-address": "10.5.0",
 	undici: "8.10.0",

--- a/scripts/verify-package-artifact.mjs
+++ b/scripts/verify-package-artifact.mjs
@@ -28,8 +28,8 @@ const packageRoot = resolve(process.argv[2] ?? resolve(import.meta.dirname, ".."
 const packageRequire = createRequire(resolve(packageRoot, "package.json"));
 const FEYNMAN_BRACE_EXPANSION_VERSION = "5.0.9";
 const FEYNMAN_IP_ADDRESS_VERSION = "10.5.0";
-const FEYNMAN_LITEPARSE_VERSION = "2.12.0";
-const FEYNMAN_LITEPARSE_INTEGRITY = "sha512-Tgay0LlZIAAuJVWYd7vIpaE46zJG4riYSB2v06eDZalF8bu1PJBHh4XtOYkod954TeuJA7ilJ/I/akkcWt4+mg==";
+const FEYNMAN_LITEPARSE_VERSION = "2.13.0";
+const FEYNMAN_LITEPARSE_INTEGRITY = "sha512-Gbe9oBrllB7R81R80ztZoYvJnxHx1n9ggl+idpq1Nb8LRz95tYb1dDVGeH02JbJPgCl6ewK3V9HMIb4FbXGu0g==";
 const FEYNMAN_LITEPARSE_NATIVE_PACKAGES = [
 	"@llamaindex/liteparse-darwin-arm64",
 	"@llamaindex/liteparse-darwin-x64",

--- a/tests/package-seeding.test.ts
+++ b/tests/package-seeding.test.ts
@@ -67,7 +67,7 @@ test("prepare runtime workspace pins audited transitive runtime overrides", asyn
 	assert.match(runtimeWorkspaceSource, /"@mozilla\/readability": "0\.6\.0"/);
 	assert.match(runtimeWorkspaceSource, /"@opentelemetry\/sdk-node": "0\.221\.0"/);
 	assert.match(runtimeWorkspaceSource, /"@opentelemetry\/resources": "2\.10\.0"/);
-	assert.match(runtimeWorkspaceSource, /"@llamaindex\/liteparse": "2\.12\.0"/);
+	assert.match(runtimeWorkspaceSource, /"@llamaindex\/liteparse": "2\.13\.0"/);
 	assert.match(runtimeWorkspaceSource, /"ip-address": "10\.5\.0"/);
 	assert.match(runtimeWorkspaceSource, /undici: "8\.10\.0"/);
 	assert.match(runtimeWorkspaceSource, /"undici",\n\];/);
@@ -86,15 +86,15 @@ test("installed runtime scripts follow npm's platform-specific global prefix lay
 	}
 });
 
-test("0.3.22 release notes name the current research runtime updates", () => {
+test("0.3.24 release notes name the current document research runtime update", () => {
 	for (const path of [
 		resolve(process.cwd(), "RELEASES.md"),
 		resolve(process.cwd(), "website", "src", "content", "docs", "reference", "releases.md"),
 	]) {
 		const releases = readFileSync(path, "utf8");
-		const currentRelease = releases.match(/## v0\.3\.22[\s\S]*?(?=\n## v0\.3\.21)/)?.[0] ?? "";
-		assert.match(currentRelease, /bundled Pi runtime to `0\.84\.2`/);
-		assert.match(currentRelease, /`pi-web-access` to `0\.23\.0`/);
+		const currentRelease = releases.match(/## v0\.3\.24[\s\S]*?(?=\n## v0\.3\.23)/)?.[0] ?? "";
+		assert.match(currentRelease, /bundled LiteParse runtime to `2\.13\.0`/);
+		assert.match(currentRelease, /garbled-text detection/i);
 	}
 });
 
@@ -144,9 +144,9 @@ test("release manifests pin current document and website security repairs", () =
 		"@llamaindex/liteparse-win32-arm64-msvc",
 		"@llamaindex/liteparse-win32-x64-msvc",
 	]) {
-		assert.equal(manifest.optionalDependencies?.[packageName], "2.12.0");
-		assert.equal(lock.packages?.[""]?.optionalDependencies?.[packageName], "2.12.0");
-		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.version, "2.12.0");
+		assert.equal(manifest.optionalDependencies?.[packageName], "2.13.0");
+		assert.equal(lock.packages?.[""]?.optionalDependencies?.[packageName], "2.13.0");
+		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.version, "2.13.0");
 		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.optional, true);
 	}
 	assert.equal(websiteManifest.overrides?.["js-yaml"], "4.3.1");

--- a/tests/runtime-workspace-lock.test.ts
+++ b/tests/runtime-workspace-lock.test.ts
@@ -51,9 +51,9 @@ test("vendored runtime uses a committed exact dependency lock", () => {
 			integrity: (runtimeLock.packages["node_modules/@llamaindex/liteparse"] as { integrity?: string })?.integrity,
 		},
 		{
-			version: "2.12.0",
-			resolved: "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.12.0.tgz",
-			integrity: "sha512-Tgay0LlZIAAuJVWYd7vIpaE46zJG4riYSB2v06eDZalF8bu1PJBHh4XtOYkod954TeuJA7ilJ/I/akkcWt4+mg==",
+			version: "2.13.0",
+			resolved: "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.13.0.tgz",
+			integrity: "sha512-Gbe9oBrllB7R81R80ztZoYvJnxHx1n9ggl+idpq1Nb8LRz95tYb1dDVGeH02JbJPgCl6ewK3V9HMIb4FbXGu0g==",
 		},
 	);
 	assert.equal(runtimeLock.packages["node_modules/undici"]?.version, "8.10.0");

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,16 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.24 - 2026-08-15
+
+### Document research
+
+- Updated the bundled LiteParse runtime to `2.13.0`. Document parsing now improves garbled-text detection for mixed-font papers and uses layout-aware block classification for richer structured extraction. The existing parse, search, and screenshot tools keep their current interface.
+
+### Validation
+
+- Re-ran the installed document parse, search, and screenshot flow against the bundled runtime.
+
 ## v0.3.23 - 2026-08-15
 
 ### Provider login reliability


### PR DESCRIPTION
## Summary

- Update the bundled LiteParse document research runtime from `2.12.0` to `2.13.0`.
- Improve mixed-font garbled-text detection and layout-aware structured extraction for paper reading.
- Bump Feynman to `0.3.24` and refresh native package locks, artifact gates, release notes, and website release notes.

## Evidence

- Upstream LiteParse release: `node-v2.13.0` at `36e7431`.
- Local source/runtime direct block probe passed.
- `npm test`: `784/784`.
- Typecheck, build, architecture check, website lint/typecheck/build, root/site production audits, diff check, package verifier, clean consumer audits, installed runtime/document verifiers, and CLI smoke passed.
- Real pack: `114842276` bytes, `29140` files, SHA-256 `1523c00e0b446942303499e0aab366b1c7dd33ef6b12fa0a9e9957e3cbf62545`.

Exact-head Daytona proof and release publication remain required before merge.
