### PR TITLE
release: update LiteParse to 2.13.1

### DIFF
--- a/.feynman/runtime-package-lock.json
+++ b/.feynman/runtime-package-lock.json
@@ -2455,9 +2455,9 @@
       }
     },
     "node_modules/@llamaindex/liteparse": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.13.0.tgz",
-      "integrity": "sha512-Gbe9oBrllB7R81R80ztZoYvJnxHx1n9ggl+idpq1Nb8LRz95tYb1dDVGeH02JbJPgCl6ewK3V9HMIb4FbXGu0g==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.13.1.tgz",
+      "integrity": "sha512-EtMFEYFZIY+Gpj6nebvyiIkU9NTmLG5CXe2WpYy5S0pjCLfFgW0Tn9iN68ik3QIk64ELSdLJlgijSzCzfSpeoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"
@@ -2470,19 +2470,19 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@llamaindex/liteparse-darwin-arm64": "2.13.0",
-        "@llamaindex/liteparse-darwin-x64": "2.13.0",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.13.0",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.13.0",
-        "@llamaindex/liteparse-linux-x64-musl": "2.13.0",
-        "@llamaindex/liteparse-win32-arm64-msvc": "2.13.0",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.13.0"
+        "@llamaindex/liteparse-darwin-arm64": "2.13.1",
+        "@llamaindex/liteparse-darwin-x64": "2.13.1",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.13.1",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.13.1",
+        "@llamaindex/liteparse-linux-x64-musl": "2.13.1",
+        "@llamaindex/liteparse-win32-arm64-msvc": "2.13.1",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.13.1"
       }
     },
     "node_modules/@llamaindex/liteparse-darwin-arm64": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.13.0.tgz",
-      "integrity": "sha512-m5u24zyn5NNdPz4Tl7Hp7riEUqsLYBKsS6blgW+KYzo1hr4QbfR5K9oA5T0R1XPKGsNv3vqbwtkdxJpSSeH8MA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.13.1.tgz",
+      "integrity": "sha512-twznsLWeUD0QtSmZjjEQOZF/opFjJORbSILLNz41eM4PP0O2WT87ZAdUxLnPiA7JPZ6TdfoEc9lvAJfQPUHNig==",
       "cpu": [
         "arm64"
       ],
@@ -2493,9 +2493,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-darwin-x64": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.13.0.tgz",
-      "integrity": "sha512-u7rOvbGn8ofGjBBKalYB1JSdTpQATEvEOnCYM/8PhNMfBkpDZxfTyxpese0IMa2kp9i6QghNHxtTyl0gOhQFLA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.13.1.tgz",
+      "integrity": "sha512-Im0RwZCztuK+x+may8QRvtFhk1rfGtVMYHvKRHXh+NG+reWFKCTpUkOGrlrW5ik4lu3nzd4Svjbg015zw8zCRQ==",
       "cpu": [
         "x64"
       ],
@@ -2506,9 +2506,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-arm64-gnu": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.13.0.tgz",
-      "integrity": "sha512-cpyOhwYY2UGvQ0zlKNUuLnAyVZP0+GpoGaM6asnPmV42yv6noDWTWhhmfi25DsECK+k12frKuCwinUSAziidTw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.13.1.tgz",
+      "integrity": "sha512-L0n95I/xdYS2pt2Eb0Fr0EhianUSZlR6SM84V1ZSGLzZJVZqxAKo9OcoTO8KFd5SnbRjv5B3AOarbeXcbwbJ4g==",
       "cpu": [
         "arm64"
       ],
@@ -2522,9 +2522,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-gnu": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.13.0.tgz",
-      "integrity": "sha512-smigviGSoOdm+0wh2w7flWMiFWS64V/A7DxlnQIuCsBf9S41ElSJfFSLGttDwBj1h9TQTa1tEnUPe0jeF/Mnbw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.13.1.tgz",
+      "integrity": "sha512-E0Ywt7jBjx35R5Rzd3RtPUcoPkvfef5Zp/HWvIYlTQHMkvG2e5An0qNktF+MV0Z+c5C2/7KT/3Hnb1rB3+JPsw==",
       "cpu": [
         "x64"
       ],
@@ -2538,9 +2538,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-musl": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.13.0.tgz",
-      "integrity": "sha512-GQF/iNiVtXT1rMZ4LzYD5l4mWGd4P7CuZ03QooKlOGbqD4pHLhdHAxt9YjEe7AYgLo9iJBj6lGoovNGu70hSUQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.13.1.tgz",
+      "integrity": "sha512-0s4a4laI8ND21X0dOn0d0rJNGHRV+8XpXehk/Cg7/FMzWK/5z4PO/rtJ2S/+r/A9VOM+AOKZkjgxKOMtW96qOQ==",
       "cpu": [
         "x64"
       ],
@@ -2554,9 +2554,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-arm64-msvc": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.13.0.tgz",
-      "integrity": "sha512-XtsIn1jgpY0k6yVgU2KYVNBnyaszFCe+5OBVBAkQCJcqMrUik2GYh//zaTNmknDLai5rTTa4hGdIy23lK5zLeg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.13.1.tgz",
+      "integrity": "sha512-jJ5v/jYDj9XGCorHnMzh2+W5vb+elqf87jW9o6JT7TXlm0g+sPFx+oDg4qaLXVoHJDMlHBrn7XDr0dpmjk7hbA==",
       "cpu": [
         "arm64"
       ],
@@ -2567,9 +2567,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-x64-msvc": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.13.0.tgz",
-      "integrity": "sha512-gspSELWFZJ3aYfnkBH/9+TeHM2XyqKjRCiNPJVi03StWt3BZ+EMkunTyEwUZQEpjm2vH0uhKTK9hRFPegKMLcg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.13.1.tgz",
+      "integrity": "sha512-jPMt5ji7igD7RMS/kn3gIYNnrl8iP47w7mYGK4zKn0xZbQNCSPYdhBMoAkEr5ivxen8O0c4Rxy7URp0AmN264Q==",
       "cpu": [
         "x64"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-17 03:00 EDT — liteparse-table-header-0.3.26
+
+- Objective: Adopt LiteParse `2.13.1` as Feynman `0.3.26` and prove that multi-line table headers keep in-table cells that fall between established columns.
+- Intake: Open issues, pull requests, active workflows, Dependabot alerts, and repository advisories remain empty. No fork changed after the prior sweep. Pi `0.84.2`, pi-web-access `0.23.0`, pi-docparser `4.0.0`, pi-btw `0.4.1`, pi-otel `0.1.0`, and alpha-hub `0.1.3` remain current. Pi main has unreleased provider, token-accounting, and compaction-routing work; its TUI compaction path still passes no routing session and has no Feynman defect to port. Keep `pi-subagents@0.40.0`; `0.50.0` still bundles generic workflows, scheduling, fleet, and administration.
+- Evidence: Upstream LiteParse PR `#420` merged as `2856997` after Linux, macOS, Windows, Node, Python, WASM, and output-comparison checks. The Node release run `31996133977` published all seven platform packages. A synthetic positioned-table probe loses `Detail`, `X`, `Y`, and `Z` with `2.13.0`, then preserves all four cells with `2.13.1`.
+- Changed: Updated the wrapper and seven native package pins, runtime lock, package verifier integrity, release notes, and exact-version tests. Added source-native and installed-runtime regressions for the table-header cell-loss path. Adversarial review moved the native test to Node 22-compatible loading and removed unrelated `es-module-lexer@2.3.2` lock drift.
+- Verified locally: Focused tests passed `20/20` on Node `22.22.3` and `24.18.0`; the installed document verifier returned LiteParse `2.13.1`, four table columns, one exact search hit, and a valid PNG. The full suite passed `786/786`; typecheck, build, architecture, website lint/typecheck/build (`34` pages), root/site/runtime/local-consumer audits, and `git diff --check` passed. Dry and real packs matched at `114,854,353` bytes, `298,949,625` unpacked bytes, and `29,144` files with SHA-256 `8d43486a3d24b0d21c6b2835607d1d69d62e05f843960763bf3e53f028344955`. The clean tarball consumer passed stale-Pi repair plus package, runtime, TypeBox, extension, and document checks with zero vulnerabilities. State: `unverified` for Daytona, PR CI, merge, publication, and post-release identity. Next: complete the clean-machine ladder, then merge and publish the exact tested commit.
+
 ### 2026-08-16 23:08 EDT — intake-sweep-0.3.25-current
 
 - Objective: Refresh the complete maintainer intake after the `0.3.25` release and prove that no new research-loop work or release repair remains.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-17 04:30 EDT — liteparse-node22-runtime-repair
+
+- Objective: Repair PR `#233` after its exact Node `22.22.0` candidate consumer replaced the bundled LiteParse `2.13.1` graph and failed the new table-header regression.
+- Evidence: The PR artifact and Daytona pack are byte-identical at SHA-256 `755b9c3a16cc894905f3904648a195712aea90facc47cf6fa8c6771f40809334`. Its archive contains LiteParse `2.13.1`, and the direct Node 22 verifier passes. Running `feynman --version` under Node 22 rejects the Node 24 ABI manifest, restores the archive, then overwrites `feynman-runtime` with a six-package fallback. npm consequently installs LiteParse `2.10.1`, and the verifier loses the table-header fixture.
+- Changed: Cross-ABI runtime repair now retains the verified archive package manifest and overrides, reinstalls every archived exact runtime package plus new configured packages, uses npm `--save-exact`, and records the full repaired package set. Added focused merge and source-contract regressions plus public release documentation.
+- Verified locally: Focused tests passed `27/27`; the full suite passed `787/787`; typecheck, build, architecture, website lint/typecheck/build (`34` pages), root/site/runtime audits, outdated review, and diff checks passed. Dry and real packs matched at `114,854,905` bytes, `298,950,889` unpacked bytes, and `29,144` files with SHA-256 `efcb79007257a04466c7308c1cf9660075513b1512287a87b6c22ec9e6f4ff55`. Clean Node 24 and Node `22.22.0` local/global consumers passed zero-vulnerability audits, stale-Pi repair, package, `15`-tool/`9`-command RPC, TypeBox, extension, parse, search, screenshot, and four-column table checks. The Node 22 repaired workspace retained all `13` exact runtime packages plus LiteParse `2.13.1`, Pi `0.84.2`, and Undici `8.10.0`.
+- State: `unverified` for replacement Daytona proof, amended PR CI, merge, publication, and post-release identity. Next: push the exact candidate, rerun clean Linux proof, then merge and publish PR `#233`.
+
 ### 2026-08-17 03:00 EDT — liteparse-table-header-0.3.26
 
 - Objective: Adopt LiteParse `2.13.1` as Feynman `0.3.26` and prove that multi-line table headers keep in-table cells that fall between established columns.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,17 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.26 - 2026-08-17
+
+### Document research
+
+- Updated the bundled LiteParse runtime to `2.13.1`. Multi-line table headers now keep in-table cells between established columns instead of silently dropping them. The existing parse, search, and screenshot tools keep their current interface.
+
+### Validation
+
+- Added an installed-runtime regression that reproduces the lost table-header cell and checks the corrected Markdown table.
+- Re-ran the installed document parse, search, and screenshot flow against the bundled runtime.
+
 ## v0.3.25 - 2026-08-16
 
 ### Research agents

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,7 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 - Added an installed-runtime regression that reproduces the lost table-header cell and checks the corrected Markdown table.
 - Re-ran the installed document parse, search, and screenshot flow against the bundled runtime.
+- Fixed cross-Node runtime repair to preserve the bundled exact package manifest and overrides. Node 22 consumers now keep LiteParse `2.13.1` instead of reinstalling pi-docparser's older transitive default.
 
 ## v0.3.25 - 2026-08-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",
@@ -76,13 +76,13 @@
         "node": ">=22.22.0 <26"
       },
       "optionalDependencies": {
-        "@llamaindex/liteparse-darwin-arm64": "2.13.0",
-        "@llamaindex/liteparse-darwin-x64": "2.13.0",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.13.0",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.13.0",
-        "@llamaindex/liteparse-linux-x64-musl": "2.13.0",
-        "@llamaindex/liteparse-win32-arm64-msvc": "2.13.0",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.13.0"
+        "@llamaindex/liteparse-darwin-arm64": "2.13.1",
+        "@llamaindex/liteparse-darwin-x64": "2.13.1",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.13.1",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.13.1",
+        "@llamaindex/liteparse-linux-x64-musl": "2.13.1",
+        "@llamaindex/liteparse-win32-arm64-msvc": "2.13.1",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.13.1"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -3874,9 +3874,9 @@
       }
     },
     "node_modules/@llamaindex/liteparse-darwin-arm64": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.13.0.tgz",
-      "integrity": "sha512-m5u24zyn5NNdPz4Tl7Hp7riEUqsLYBKsS6blgW+KYzo1hr4QbfR5K9oA5T0R1XPKGsNv3vqbwtkdxJpSSeH8MA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.13.1.tgz",
+      "integrity": "sha512-twznsLWeUD0QtSmZjjEQOZF/opFjJORbSILLNz41eM4PP0O2WT87ZAdUxLnPiA7JPZ6TdfoEc9lvAJfQPUHNig==",
       "cpu": [
         "arm64"
       ],
@@ -3887,9 +3887,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-darwin-x64": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.13.0.tgz",
-      "integrity": "sha512-u7rOvbGn8ofGjBBKalYB1JSdTpQATEvEOnCYM/8PhNMfBkpDZxfTyxpese0IMa2kp9i6QghNHxtTyl0gOhQFLA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.13.1.tgz",
+      "integrity": "sha512-Im0RwZCztuK+x+may8QRvtFhk1rfGtVMYHvKRHXh+NG+reWFKCTpUkOGrlrW5ik4lu3nzd4Svjbg015zw8zCRQ==",
       "cpu": [
         "x64"
       ],
@@ -3900,9 +3900,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-arm64-gnu": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.13.0.tgz",
-      "integrity": "sha512-cpyOhwYY2UGvQ0zlKNUuLnAyVZP0+GpoGaM6asnPmV42yv6noDWTWhhmfi25DsECK+k12frKuCwinUSAziidTw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.13.1.tgz",
+      "integrity": "sha512-L0n95I/xdYS2pt2Eb0Fr0EhianUSZlR6SM84V1ZSGLzZJVZqxAKo9OcoTO8KFd5SnbRjv5B3AOarbeXcbwbJ4g==",
       "cpu": [
         "arm64"
       ],
@@ -3916,9 +3916,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-gnu": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.13.0.tgz",
-      "integrity": "sha512-smigviGSoOdm+0wh2w7flWMiFWS64V/A7DxlnQIuCsBf9S41ElSJfFSLGttDwBj1h9TQTa1tEnUPe0jeF/Mnbw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.13.1.tgz",
+      "integrity": "sha512-E0Ywt7jBjx35R5Rzd3RtPUcoPkvfef5Zp/HWvIYlTQHMkvG2e5An0qNktF+MV0Z+c5C2/7KT/3Hnb1rB3+JPsw==",
       "cpu": [
         "x64"
       ],
@@ -3932,9 +3932,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-musl": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.13.0.tgz",
-      "integrity": "sha512-GQF/iNiVtXT1rMZ4LzYD5l4mWGd4P7CuZ03QooKlOGbqD4pHLhdHAxt9YjEe7AYgLo9iJBj6lGoovNGu70hSUQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.13.1.tgz",
+      "integrity": "sha512-0s4a4laI8ND21X0dOn0d0rJNGHRV+8XpXehk/Cg7/FMzWK/5z4PO/rtJ2S/+r/A9VOM+AOKZkjgxKOMtW96qOQ==",
       "cpu": [
         "x64"
       ],
@@ -3948,9 +3948,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-arm64-msvc": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.13.0.tgz",
-      "integrity": "sha512-XtsIn1jgpY0k6yVgU2KYVNBnyaszFCe+5OBVBAkQCJcqMrUik2GYh//zaTNmknDLai5rTTa4hGdIy23lK5zLeg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.13.1.tgz",
+      "integrity": "sha512-jJ5v/jYDj9XGCorHnMzh2+W5vb+elqf87jW9o6JT7TXlm0g+sPFx+oDg4qaLXVoHJDMlHBrn7XDr0dpmjk7hbA==",
       "cpu": [
         "arm64"
       ],
@@ -3961,9 +3961,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-x64-msvc": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.13.0.tgz",
-      "integrity": "sha512-gspSELWFZJ3aYfnkBH/9+TeHM2XyqKjRCiNPJVi03StWt3BZ+EMkunTyEwUZQEpjm2vH0uhKTK9hRFPegKMLcg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.13.1.tgz",
+      "integrity": "sha512-jPMt5ji7igD7RMS/kn3gIYNnrl8iP47w7mYGK4zKn0xZbQNCSPYdhBMoAkEr5ivxen8O0c4Rxy7URp0AmN264Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",
@@ -196,12 +196,12 @@
   },
   "author": "",
   "optionalDependencies": {
-    "@llamaindex/liteparse-darwin-arm64": "2.13.0",
-    "@llamaindex/liteparse-darwin-x64": "2.13.0",
-    "@llamaindex/liteparse-linux-arm64-gnu": "2.13.0",
-    "@llamaindex/liteparse-linux-x64-gnu": "2.13.0",
-    "@llamaindex/liteparse-linux-x64-musl": "2.13.0",
-    "@llamaindex/liteparse-win32-arm64-msvc": "2.13.0",
-    "@llamaindex/liteparse-win32-x64-msvc": "2.13.0"
+    "@llamaindex/liteparse-darwin-arm64": "2.13.1",
+    "@llamaindex/liteparse-darwin-x64": "2.13.1",
+    "@llamaindex/liteparse-linux-arm64-gnu": "2.13.1",
+    "@llamaindex/liteparse-linux-x64-gnu": "2.13.1",
+    "@llamaindex/liteparse-linux-x64-musl": "2.13.1",
+    "@llamaindex/liteparse-win32-arm64-msvc": "2.13.1",
+    "@llamaindex/liteparse-win32-x64-msvc": "2.13.1"
   }
 }

--- a/scripts/lib/runtime-workspace-integrity.d.mts
+++ b/scripts/lib/runtime-workspace-integrity.d.mts
@@ -14,6 +14,10 @@ export declare function runtimeManifestPackagesMatch(
 	manifestPackageSpecs: string[],
 	configuredPackageSpecs?: string[],
 ): boolean;
+export declare function mergeRuntimePackageSpecs(
+	manifestPackageSpecs: unknown,
+	configuredPackageSpecs: unknown,
+): string[];
 
 export declare function computeFileSha256(path: string): string;
 export declare function computeRuntimeInputHash(

--- a/scripts/lib/runtime-workspace-integrity.mjs
+++ b/scripts/lib/runtime-workspace-integrity.mjs
@@ -78,6 +78,19 @@ export function runtimeManifestPackagesMatch(
 	return workspacePackagesMatch(nodeModulesPath, manifestPackageSpecs);
 }
 
+export function mergeRuntimePackageSpecs(manifestPackageSpecs, configuredPackageSpecs) {
+	const merged = [];
+	for (const spec of [
+		...(Array.isArray(manifestPackageSpecs) ? manifestPackageSpecs : []),
+		...(Array.isArray(configuredPackageSpecs) ? configuredPackageSpecs : []),
+	]) {
+		if (typeof spec === "string" && !merged.includes(spec)) {
+			merged.push(spec);
+		}
+	}
+	return merged;
+}
+
 export function computeFileSha256(path) {
 	return createHash("sha256").update(readFileSync(path)).digest("hex");
 }

--- a/scripts/patch-embedded-pi.mjs
+++ b/scripts/patch-embedded-pi.mjs
@@ -31,6 +31,7 @@ import {
 	patchPiTuiSource,
 } from "./lib/pi-tui-patch.mjs";
 import {
+	mergeRuntimePackageSpecs,
 	runtimeManifestPackagesMatch,
 	verifyFileSha256,
 } from "./lib/runtime-workspace-integrity.mjs";
@@ -326,6 +327,7 @@ function createInstallCommand(packageManager, packageSpecs) {
 				"install",
 				"--global=false",
 				"--location=project",
+				"--save-exact",
 				"--prefer-offline",
 				"--no-audit",
 				"--no-fund",
@@ -425,6 +427,17 @@ function parsePackageName(spec) {
 function filterUnsupportedPackageSpecs(packageSpecs) {
 	if (supportsNativePackageSources()) return packageSpecs;
 	return packageSpecs.filter((spec) => !NATIVE_PACKAGE_SPECS.has(parsePackageName(spec)));
+}
+
+function readWorkspaceInstallPackageSpecs(configuredPackageSpecs) {
+	try {
+		const manifest = JSON.parse(readFileSync(workspaceManifestPath, "utf8"));
+		return filterUnsupportedPackageSpecs(
+			mergeRuntimePackageSpecs(manifest.packageSpecs, configuredPackageSpecs),
+		);
+	} catch {
+		return configuredPackageSpecs;
+	}
 }
 
 function workspaceMatchesRuntime(packageSpecs) {
@@ -723,12 +736,15 @@ function ensurePackageWorkspaceUnlocked() {
 		return;
 	}
 
+	const installPackageSpecs = readWorkspaceInstallPackageSpecs(supportedPackageSpecs);
 	mkdirSync(workspaceDir, { recursive: true });
-	writeFileSync(
-		workspacePackageJsonPath,
-		JSON.stringify({ name: "feynman-packages", private: true }, null, 2) + "\n",
-		"utf8",
-	);
+	if (!existsSync(workspacePackageJsonPath)) {
+		writeFileSync(
+			workspacePackageJsonPath,
+			JSON.stringify({ name: "feynman-packages", private: true }, null, 2) + "\n",
+			"utf8",
+		);
+	}
 
 	const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 	let frame = 0;
@@ -738,7 +754,7 @@ function ensurePackageWorkspaceUnlocked() {
 		process.stderr.write(`\r${frames[frame++ % frames.length]} setting up feynman... ${elapsed}s`);
 	}, 80);
 
-	const result = installWorkspacePackages(supportedPackageSpecs);
+	const result = installWorkspacePackages(installPackageSpecs);
 
 	clearInterval(spinner);
 	const elapsed = Math.round((Date.now() - start) / 1000);
@@ -747,7 +763,7 @@ function ensurePackageWorkspaceUnlocked() {
 		process.stderr.write(`\r✗ setup failed (${elapsed}s)\n`);
 	} else {
 		process.stderr.write("\r\x1b[2K");
-		writeWorkspaceManifest(supportedPackageSpecs);
+		writeWorkspaceManifest(installPackageSpecs);
 		ensureBundledPackageLinks(supportedPackageSpecs);
 	}
 }

--- a/scripts/prepare-runtime-workspace.mjs
+++ b/scripts/prepare-runtime-workspace.mjs
@@ -89,7 +89,7 @@ const RUNTIME_PACKAGE_OVERRIDES = {
 	"@opentelemetry/sdk-node": "0.221.0",
 	"@opentelemetry/sdk-trace-base": "2.10.0",
 	"@opentelemetry/sdk-trace-node": "2.10.0",
-	"@llamaindex/liteparse": "2.13.0",
+	"@llamaindex/liteparse": "2.13.1",
 	"brace-expansion": "5.0.9",
 	"ip-address": "10.5.0",
 	undici: "8.10.0",

--- a/scripts/verify-installed-docparser.mjs
+++ b/scripts/verify-installed-docparser.mjs
@@ -89,6 +89,17 @@ export function resolveInstalledDocparserPaths(packageRoot = defaultPackageRoot)
 		"node_modules",
 		"pi-docparser",
 	);
+	const runtimeRoot = resolve(resolvedPackageRoot, ".feynman", "npm");
+	const runtimeRequire = createRequire(resolve(runtimeRoot, "package.json"));
+	const liteparseManifestPath = realpathSync(runtimeRequire.resolve("@llamaindex/liteparse/package.json"));
+	const liteparseManifest = JSON.parse(readFileSync(liteparseManifestPath, "utf8"));
+	const liteparseEntryPath = realpathSync(
+		resolve(liteparseManifestPath, "..", liteparseManifest.main),
+	);
+	assert.ok(
+		isPathInside(liteparseEntryPath, resolve(runtimeRoot, "node_modules")),
+		`Installed LiteParse resolved outside the runtime workspace: ${liteparseEntryPath}`,
+	);
 	const extensionPath = resolve(docparserRoot, "extensions", "docparser", "index.ts");
 	assert.ok(existsSync(extensionPath), `Installed pi-docparser extension is missing: ${extensionPath}`);
 	return {
@@ -98,6 +109,8 @@ export function resolveInstalledDocparserPaths(packageRoot = defaultPackageRoot)
 		jitiManifestPath,
 		docparserRoot,
 		extensionPath,
+		liteparseEntryPath,
+		liteparseManifestPath,
 	};
 }
 
@@ -142,6 +155,64 @@ export function assertDocumentScreenshotResult(result) {
 	return result.details.outputDir;
 }
 
+export function createTableHeaderProbePage() {
+	const item = (text, x, y, width = 20) => ({
+		text,
+		x,
+		y,
+		width,
+		height: 6,
+		fontName: "Helvetica",
+		fontSize: 5,
+		fontHeight: 5,
+		fontWeight: 400,
+		words: [],
+	});
+	return {
+		pageNumber: 1,
+		pageWidth: 500,
+		pageHeight: 700,
+		textItems: [
+			item("Model", 50, 100),
+			item("Metric A", 170, 100),
+			item("Metric B", 290, 100),
+			item("Family", 50, 110),
+			item("Detail", 159, 110, 3),
+			item("Score A", 170, 110),
+			item("Score B", 290, 110),
+			item("Alpha", 50, 120),
+			item("X", 159, 120, 3),
+			item("10", 170, 120),
+			item("20", 290, 120),
+			item("Beta", 50, 130),
+			item("Y", 159, 130, 3),
+			item("11", 170, 130),
+			item("21", 290, 130),
+			item("Gamma", 50, 140),
+			item("Z", 159, 140, 3),
+			item("12", 170, 140),
+			item("22", 290, 140),
+		],
+	};
+}
+
+export function assertTableHeaderProbeResult(result) {
+	const markdown = result?.pages?.[0]?.markdown ?? result?.text ?? "";
+	for (const expectedRow of [
+		"| Model |  | Metric A | Metric B |",
+		"| Family | Detail | Score A | Score B |",
+		"| Alpha | X | 10 | 20 |",
+		"| Beta | Y | 11 | 21 |",
+		"| Gamma | Z | 12 | 22 |",
+	]) {
+		assert.ok(
+			markdown.includes(expectedRow),
+			`LiteParse lost an in-table cell from the multi-line header fixture: ${expectedRow}`,
+		);
+	}
+	return markdown;
+}
+
 export async function verifyInstalledDocparser(options = {}) {
 	const paths = resolveInstalledDocparserPaths(options.packageRoot);
 	const root = await mkdtemp(resolve(tmpdir(), "feynman-installed-docparser-"));
@@ -165,6 +236,16 @@ export async function verifyInstalledDocparser(options = {}) {
 		writeFileSync(pdfPath, createMinimalPdf());
 		const jitiModule = await import(pathToFileURL(paths.jitiEntryPath).href);
 		assert.equal(typeof jitiModule.createJiti, "function", "Pi's installed Jiti has no createJiti");
+		const liteparseModule = await import(pathToFileURL(paths.liteparseEntryPath).href);
+		assert.equal(typeof liteparseModule.LiteParse, "function", "Installed LiteParse has no parser");
+		const tableParser = new liteparseModule.LiteParse({
+			ocrEnabled: false,
+			outputFormat: "markdown",
+			quiet: true,
+		});
+		const tableMarkdown = assertTableHeaderProbeResult(
+			tableParser.parsePages([createTableHeaderProbePage()]),
+		);
 		const jiti = jitiModule.createJiti(import.meta.url, { moduleCache: false });
 		const extension = await jiti.import(
 			process.platform === "win32"
@@ -225,10 +306,12 @@ export async function verifyInstalledDocparser(options = {}) {
 			docparser: JSON.parse(
 				readFileSync(resolve(paths.docparserRoot, "package.json"), "utf8"),
 			).version,
+			liteparse: JSON.parse(readFileSync(paths.liteparseManifestPath, "utf8")).version,
 			jiti: jitiManifest.version,
 			pageCount: parseResult.details.pageCount,
 			hits: searchResult.details.hits.length,
 			pngBytes: screenshotResult.details.screenshots[0].bytes,
+			tableColumns: tableMarkdown.split("\n")[0].split("|").length - 2,
 		};
 	} catch (error) {
 		primaryError = error;

--- a/scripts/verify-package-artifact.mjs
+++ b/scripts/verify-package-artifact.mjs
@@ -26,8 +26,8 @@ const packageRoot = resolve(process.argv[2] ?? resolve(import.meta.dirname, ".."
 const packageRequire = createRequire(resolve(packageRoot, "package.json"));
 const FEYNMAN_BRACE_EXPANSION_VERSION = "5.0.9";
 const FEYNMAN_IP_ADDRESS_VERSION = "10.5.0";
-const FEYNMAN_LITEPARSE_VERSION = "2.13.0";
-const FEYNMAN_LITEPARSE_INTEGRITY = "sha512-Gbe9oBrllB7R81R80ztZoYvJnxHx1n9ggl+idpq1Nb8LRz95tYb1dDVGeH02JbJPgCl6ewK3V9HMIb4FbXGu0g==";
+const FEYNMAN_LITEPARSE_VERSION = "2.13.1";
+const FEYNMAN_LITEPARSE_INTEGRITY = "sha512-EtMFEYFZIY+Gpj6nebvyiIkU9NTmLG5CXe2WpYy5S0pjCLfFgW0Tn9iN68ik3QIk64ELSdLJlgijSzCzfSpeoQ==";
 const FEYNMAN_LITEPARSE_NATIVE_PACKAGES = [
 	"@llamaindex/liteparse-darwin-arm64",
 	"@llamaindex/liteparse-darwin-x64",

--- a/tests/liteparse-table-header.test.ts
+++ b/tests/liteparse-table-header.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+
+function nativeLiteParsePackage() {
+	if (process.platform === "darwin" && process.arch === "arm64") {
+		return "@llamaindex/liteparse-darwin-arm64";
+	}
+	if (process.platform === "darwin" && process.arch === "x64") {
+		return "@llamaindex/liteparse-darwin-x64";
+	}
+	if (process.platform === "linux" && process.arch === "arm64") {
+		return "@llamaindex/liteparse-linux-arm64-gnu";
+	}
+	if (process.platform === "linux" && process.arch === "x64") {
+		const report = process.report?.getReport() as {
+			header?: { glibcVersionRuntime?: string };
+		};
+		return report?.header?.glibcVersionRuntime
+			? "@llamaindex/liteparse-linux-x64-gnu"
+			: "@llamaindex/liteparse-linux-x64-musl";
+	}
+	if (process.platform === "win32" && process.arch === "arm64") {
+		return "@llamaindex/liteparse-win32-arm64-msvc";
+	}
+	if (process.platform === "win32" && process.arch === "x64") {
+		return "@llamaindex/liteparse-win32-x64-msvc";
+	}
+	throw new Error(`Unsupported LiteParse test platform: ${process.platform}-${process.arch}`);
+}
+
+function tableHeaderProbePage() {
+	const item = (text: string, x: number, y: number, width = 20) => ({
+		text,
+		x,
+		y,
+		width,
+		height: 6,
+		fontName: "Helvetica",
+		fontSize: 5,
+		fontHeight: 5,
+		fontWeight: 400,
+		words: [],
+	});
+	return {
+		pageNumber: 1,
+		pageWidth: 500,
+		pageHeight: 700,
+		textItems: [
+			item("Model", 50, 100),
+			item("Metric A", 170, 100),
+			item("Metric B", 290, 100),
+			item("Family", 50, 110),
+			item("Detail", 159, 110, 3),
+			item("Score A", 170, 110),
+			item("Score B", 290, 110),
+			item("Alpha", 50, 120),
+			item("X", 159, 120, 3),
+			item("10", 170, 120),
+			item("20", 290, 120),
+			item("Beta", 50, 130),
+			item("Y", 159, 130, 3),
+			item("11", 170, 130),
+			item("21", 290, 130),
+			item("Gamma", 50, 140),
+			item("Z", 159, 140, 3),
+			item("12", 170, 140),
+			item("22", 290, 140),
+		],
+	};
+}
+
+test("bundled LiteParse preserves in-table cells from multi-line headers", async () => {
+	const nativePackage = nativeLiteParsePackage();
+	const nativeModule = require(nativePackage);
+	const LiteParse = nativeModule.LiteParse ?? nativeModule.default?.LiteParse;
+	assert.equal(typeof LiteParse, "function", `${nativePackage} has no LiteParse`);
+	const parser = new LiteParse({
+		ocrEnabled: false,
+		outputFormat: "markdown",
+		quiet: true,
+	});
+	const result = parser.parsePages([tableHeaderProbePage()]);
+	const markdown = result?.pages?.[0]?.markdown ?? result?.text ?? "";
+
+	for (const expectedRow of [
+		"| Model |  | Metric A | Metric B |",
+		"| Family | Detail | Score A | Score B |",
+		"| Alpha | X | 10 | 20 |",
+		"| Beta | Y | 11 | 21 |",
+		"| Gamma | Z | 12 | 22 |",
+	]) {
+		assert.ok(markdown.includes(expectedRow), `LiteParse lost table content: ${expectedRow}`);
+	}
+});

--- a/tests/package-seeding.test.ts
+++ b/tests/package-seeding.test.ts
@@ -79,7 +79,7 @@ test("prepare runtime workspace pins audited transitive runtime overrides", asyn
 	assert.match(runtimeWorkspaceSource, /"@mozilla\/readability": "0\.6\.0"/);
 	assert.match(runtimeWorkspaceSource, /"@opentelemetry\/sdk-node": "0\.221\.0"/);
 	assert.match(runtimeWorkspaceSource, /"@opentelemetry\/resources": "2\.10\.0"/);
-	assert.match(runtimeWorkspaceSource, /"@llamaindex\/liteparse": "2\.13\.0"/);
+	assert.match(runtimeWorkspaceSource, /"@llamaindex\/liteparse": "2\.13\.1"/);
 	assert.match(runtimeWorkspaceSource, /"ip-address": "10\.5\.0"/);
 	assert.match(runtimeWorkspaceSource, /undici: "8\.10\.0"/);
 	assert.match(runtimeWorkspaceSource, /"undici",\n\];/);
@@ -98,19 +98,16 @@ test("installed runtime scripts follow npm's platform-specific global prefix lay
 	}
 });
 
-test("0.3.25 release notes name malformed-agent isolation", () => {
+test("0.3.26 release notes name the table-header extraction repair", () => {
 	for (const path of [
 		resolve(process.cwd(), "RELEASES.md"),
 		resolve(process.cwd(), "website", "src", "content", "docs", "reference", "releases.md"),
 	]) {
 		const releases = readFileSync(path, "utf8");
-		const currentRelease = releases.match(/## v0\.3\.25[\s\S]*?(?=\n## v0\.3\.24)/)?.[0] ?? "";
-		assert.match(currentRelease, /malformed custom agent definition/i);
-		assert.match(currentRelease, /unrelated valid research agents/i);
-		assert.match(currentRelease, /invalid configuration/i);
-		assert.match(currentRelease, /pi-web-access@0\.22\.0/);
-		assert.match(currentRelease, /bundled `0\.23\.0` release/i);
-		assert.match(currentRelease, /split prompt metadata/i);
+		const currentRelease = releases.match(/## v0\.3\.26[\s\S]*?(?=\n## v0\.3\.25)/)?.[0] ?? "";
+		assert.match(currentRelease, /bundled LiteParse runtime to `2\.13\.1`/i);
+		assert.match(currentRelease, /multi-line table headers/i);
+		assert.match(currentRelease, /silently dropping/i);
 	}
 });
 
@@ -160,9 +157,9 @@ test("release manifests pin current document and website security repairs", () =
 		"@llamaindex/liteparse-win32-arm64-msvc",
 		"@llamaindex/liteparse-win32-x64-msvc",
 	]) {
-		assert.equal(manifest.optionalDependencies?.[packageName], "2.13.0");
-		assert.equal(lock.packages?.[""]?.optionalDependencies?.[packageName], "2.13.0");
-		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.version, "2.13.0");
+		assert.equal(manifest.optionalDependencies?.[packageName], "2.13.1");
+		assert.equal(lock.packages?.[""]?.optionalDependencies?.[packageName], "2.13.1");
+		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.version, "2.13.1");
 		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.optional, true);
 	}
 	assert.equal(websiteManifest.overrides?.["js-yaml"], "4.3.1");

--- a/tests/package-seeding.test.ts
+++ b/tests/package-seeding.test.ts
@@ -75,6 +75,7 @@ test("prepare runtime workspace hash tracks every transitive patch file", async 
 
 test("prepare runtime workspace pins audited transitive runtime overrides", async () => {
 	const runtimeWorkspaceSource = readFileSync(resolve(process.cwd(), "scripts", "prepare-runtime-workspace.mjs"), "utf8");
+	const installedRuntimeSource = readFileSync(resolve(process.cwd(), "scripts", "patch-embedded-pi.mjs"), "utf8");
 
 	assert.match(runtimeWorkspaceSource, /"@mozilla\/readability": "0\.6\.0"/);
 	assert.match(runtimeWorkspaceSource, /"@opentelemetry\/sdk-node": "0\.221\.0"/);
@@ -84,6 +85,10 @@ test("prepare runtime workspace pins audited transitive runtime overrides", asyn
 	assert.match(runtimeWorkspaceSource, /undici: "8\.10\.0"/);
 	assert.match(runtimeWorkspaceSource, /"undici",\n\];/);
 	assert.match(runtimeWorkspaceSource, /overrides: RUNTIME_PACKAGE_OVERRIDES/);
+	assert.match(installedRuntimeSource, /mergeRuntimePackageSpecs/);
+	assert.match(installedRuntimeSource, /"--save-exact"/);
+	assert.match(installedRuntimeSource, /if \(!existsSync\(workspacePackageJsonPath\)\)/);
+	assert.match(installedRuntimeSource, /writeWorkspaceManifest\(installPackageSpecs\)/);
 });
 
 test("installed runtime scripts follow npm's platform-specific global prefix layout", () => {

--- a/tests/runtime-workspace-integrity.test.ts
+++ b/tests/runtime-workspace-integrity.test.ts
@@ -9,6 +9,7 @@ import {
 	computeRuntimeArchiveTreeHash,
 	computeRuntimeInputHash,
 	computeRuntimeTreeHash,
+	mergeRuntimePackageSpecs,
 	readArchiveEntry,
 	RUNTIME_INPUT_FILES,
 	runtimeArchiveMatches,
@@ -125,6 +126,28 @@ test("runtime manifest verification checks bundled packages beyond configured ex
 		runtimeManifestPackagesMatch(root, manifestSpecs, ["missing-package@1.0.0"]),
 		false,
 	);
+});
+
+test("runtime reinstall preserves archived exact packages and adds new configured packages", () => {
+	assert.deepEqual(
+		mergeRuntimePackageSpecs(
+			[
+				"pi-docparser@4.0.0",
+				"@earendil-works/pi-coding-agent@0.84.2",
+				"undici@8.10.0",
+			],
+			["pi-docparser@4.0.0", "pi-web-access@0.23.0"],
+		),
+		[
+			"pi-docparser@4.0.0",
+			"@earendil-works/pi-coding-agent@0.84.2",
+			"undici@8.10.0",
+			"pi-web-access@0.23.0",
+		],
+	);
+	assert.deepEqual(mergeRuntimePackageSpecs(undefined, ["pi-docparser@4.0.0"]), [
+		"pi-docparser@4.0.0",
+	]);
 });
 
 test("runtime archive integrity rejects a lock that differs from the committed graph", () => {

--- a/tests/runtime-workspace-lock.test.ts
+++ b/tests/runtime-workspace-lock.test.ts
@@ -51,9 +51,9 @@ test("vendored runtime uses a committed exact dependency lock", () => {
 			integrity: (runtimeLock.packages["node_modules/@llamaindex/liteparse"] as { integrity?: string })?.integrity,
 		},
 		{
-			version: "2.13.0",
-			resolved: "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.13.0.tgz",
-			integrity: "sha512-Gbe9oBrllB7R81R80ztZoYvJnxHx1n9ggl+idpq1Nb8LRz95tYb1dDVGeH02JbJPgCl6ewK3V9HMIb4FbXGu0g==",
+			version: "2.13.1",
+			resolved: "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.13.1.tgz",
+			integrity: "sha512-EtMFEYFZIY+Gpj6nebvyiIkU9NTmLG5CXe2WpYy5S0pjCLfFgW0Tn9iN68ik3QIk64ELSdLJlgijSzCzfSpeoQ==",
 		},
 	);
 	assert.equal(runtimeLock.packages["node_modules/undici"]?.version, "8.10.0");

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -19,6 +19,7 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 - Added an installed-runtime regression that reproduces the lost table-header cell and checks the corrected Markdown table.
 - Re-ran the installed document parse, search, and screenshot flow against the bundled runtime.
+- Fixed cross-Node runtime repair to preserve the bundled exact package manifest and overrides. Node 22 consumers now keep LiteParse `2.13.1` instead of reinstalling pi-docparser's older transitive default.
 
 ## v0.3.25 - 2026-08-16
 

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,17 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.26 - 2026-08-17
+
+### Document research
+
+- Updated the bundled LiteParse runtime to `2.13.1`. Multi-line table headers now keep in-table cells between established columns instead of silently dropping them. The existing parse, search, and screenshot tools keep their current interface.
+
+### Validation
+
+- Added an installed-runtime regression that reproduces the lost table-header cell and checks the corrected Markdown table.
+- Re-ran the installed document parse, search, and screenshot flow against the bundled runtime.
+
 ## v0.3.25 - 2026-08-16
 
 ### Research agents


### PR DESCRIPTION
## Why

LiteParse 2.13.1 fixes table extraction that dropped in-table cells between established columns in multi-line headers. This directly improves paper and document reading.

Upstream evidence:
- LiteParse PR #420 merged as `2856997c018c04cfde568e306d40de0fa0ca9f61`.
- Node release run `31996133977` published the wrapper and seven native packages.
- The synthetic fixture loses `Detail`, `X`, `Y`, and `Z` on 2.13.0 and preserves all four on 2.13.1.

## What changed

- Pin LiteParse 2.13.1 across the wrapper, all seven native packages, runtime lock, and artifact verifier.
- Add source and installed-runtime regressions for the table-header cell-loss path.
- Update release notes and public release docs for Feynman 0.3.26.
- Load the native fixture through `createRequire` for Node 22 compatibility.
- Preserve `es-module-lexer@2.3.1`; no unrelated runtime dependency drift remains.
- Preserve the archived runtime package manifest and overrides during cross-Node reinstall.
- Reinstall all 13 archived exact packages plus new configured packages with `--save-exact`.

## Node 22 repair

The first candidate run, `32007231665`, failed its Node `22.22.0` consumer because the installed runtime silently resolved LiteParse `2.10.1`.

The packaged archive had been built on Node 24. Node 22 rejected its ABI manifest, so `patch-embedded-pi.mjs` restored the archive. The installer then replaced `feynman-runtime` with only six fallback packages. That dropped the archive overrides and let `pi-docparser` install its old transitive LiteParse.

Commit `45bab8f` fixes the owning installer instead of adding a consumer fallback.

## Verification

Exact head: `45bab8fcb6c142080973b9646d28c7378b1b4c56`

Local:
- Focused tests: 27/27.
- Full tests: 787/787.
- Typecheck, build, architecture, website lint/typecheck/build (34 pages), root/site/runtime/consumer audits, and diff checks passed.
- Dry and real macOS packs matched at 114,854,905 bytes, 298,950,889 unpacked bytes, and 29,144 files; SHA-256 `efcb79007257a04466c7308c1cf9660075513b1512287a87b6c22ec9e6f4ff55`.
- Clean Node 24 and Node `22.22.0` local/global consumers passed package, stale-Pi, 15-tool/9-command RPC, TypeBox, extension, document parse/search/screenshot, and four-column table checks.

Daytona sandbox `880d5d13-9aa0-4a9b-9370-d050009d4545`:
- Exact head passed 787/787 on Node `25.9.0` plus typecheck, build, architecture, website lint/typecheck/build, root/site audits, freshness review, and diff checks.
- Node `24.18.0` dry and real Linux packs matched at 116,546,653 bytes, 300,604,747 unpacked bytes, and 29,138 files; SHA-256 `cbc36c7e187ff12437da2fa03b2e9dbe82e4b18e81bccb02e3c9e5552b2c5edf`.
- Clean Node `22.22.0` local and global consumers passed zero-vulnerability audits and all package/runtime/document gates.
- Both Node 22 paths retained 13 runtime packages, LiteParse `2.13.1`, Pi `0.84.2`, and Undici `8.10.0` from the Node 24 archive.
- The sandbox was deleted after terminal verification.
- GitHub's exact-head tarball matched the Daytona pack byte-for-byte at SHA-256 `cbc36c7e187ff12437da2fa03b2e9dbe82e4b18e81bccb02e3c9e5552b2c5edf`.

Exact-head GitHub run `32011538818` passed the release candidate, Windows installer, and all six supported Node/OS consumer jobs.
