### PR TITLE
fix: forward-port Pi provider corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-17 11:09 EDT — pi-provider-forward-fixes-0.3.27
+
+- Objective: Reproduce and carry four research-provider fixes from Pi `main` into the released `0.84.2` runtime, then finish Feynman `0.3.27`.
+- Intake: Open issues and pull requests are empty. Pi commits `af2c352`, `10acee6`, `0e4d495`, and `8720548` are unreleased but repair current Feynman behavior. The example-only `agent_settled` change and unconsumed compaction-failure event remain out of scope. The new `birhantprkc/feynman` fork equals `main`; `NioZow/feynman` still contains only the rejected generic Nix commit.
+- Reproduced: Pi `0.84.2` ignored Google thinking-level maps, dropped Bedrock gateway response headers, exposed three deprecated Xiaomi IDs, omitted three China Z.AI Coding Plan models, and kept reference-priced Z.AI costs at zero.
+- Changed: Added one removable Pi AI forward patch across source, nested, packaged, restored, and runtime-archive paths. Added exact catalog, Google, Vertex, Bedrock, installed-runtime, artifact, and idempotency regressions. Updated release notes and version metadata.
+- Verified locally: Focused runtime tests passed `27/27`; the full suite passed `792/792`; typecheck, build, architecture, website lint/typecheck/build (`34` pages), root/site/runtime/consumer audits, freshness review, and diff checks passed. Dry and real packs matched at `114,844,777` bytes, `298,899,679` unpacked bytes, and `29,141` files with SHA-256 `2a5705c9f0d89cdf9c499b320388f78584dfb9969bcda3b54ad274ddac64520c`. A clean installed tarball passed stale-Pi repair, artifact, `15`-tool/`9`-command RPC, TypeBox, Google, Vertex, Bedrock, Xiaomi, Z.AI, and document parse/search/screenshot/table gates. State: `unverified` for Daytona, exact-head CI, merge, publication, and post-release identity. Next: commit the exact candidate and finish those gates.
+
 ### 2026-08-17 06:36 EDT — liteparse-node22-0.3.26-release-complete
 
 - Objective: Finish the LiteParse `2.13.1` update and cross-Node runtime repair through exact-head CI, merge, publication, live installers, and terminal intake reconciliation.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,23 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.27 - 2026-08-17
+
+### Provider reliability
+
+- Google and Vertex models now honor model-specific thinking-level maps. Extended or remapped levels produce the supported provider level and use its matching token budget.
+- Bedrock gateway response callbacks now receive the raw Smithy response headers. Provider routing and request headers no longer disappear before Feynman can record them.
+
+### Model catalogs
+
+- Removed deprecated Xiaomi MiMo model IDs while keeping the current MiMo 2.5 models across direct and token-plan providers.
+- Added the current China Z.AI Coding Plan models, including GLM-4.6V, GLM-5.1, and GLM-5V-Turbo. Matching API-priced models now report their reference costs.
+
+### Validation
+
+- Backported four focused fixes from Pi after `0.84.2` and applied them to root, nested, packaged, and restored runtime copies.
+- Added direct Google, Vertex, Bedrock, Xiaomi, and Z.AI regressions plus installed-package and archive checks.
+
 ## v0.3.26 - 2026-08-17
 
 ### Document research

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/scripts/lib/pi-ai-forward-fixes-patch.d.mts
+++ b/scripts/lib/pi-ai-forward-fixes-patch.d.mts
@@ -1,0 +1,10 @@
+export declare const PI_AI_FORWARD_FIX_REQUIRED_VERSION: "0.84.2";
+export declare const PI_AI_FORWARD_FIX_TARGETS: readonly string[];
+export declare const PI_AI_FORWARD_FIX_MARKERS: Readonly<{
+	googleGenerativeAi: string;
+	googleShared: string;
+	googleVertex: string;
+	bedrock: string;
+}>;
+export declare function assertPiAiForwardFixSource(relativePath: string, source: string): void;
+export declare function patchPiAiForwardFixSource(relativePath: string, source: string): string;

--- a/scripts/lib/pi-ai-forward-fixes-patch.mjs
+++ b/scripts/lib/pi-ai-forward-fixes-patch.mjs
@@ -1,0 +1,444 @@
+/**
+ * Temporary Pi 0.84.2 forward patches for upstream commits:
+ * - af2c352238cffd12d404d5a4cd35a21f93a78fe0 (Google thinking maps)
+ * - 10acee6045e9025a22dff7e5220ed0d7538f12aa (Bedrock response headers)
+ * - 0e4d49541477c4fc6e404f845ad40ed47d157f24 (deprecated Xiaomi models)
+ * - 87205484bf749c2140fef5d1bea68995d57e739c (China ZAI catalog)
+ *
+ * Removal condition: delete this patch after Feynman adopts a released Pi
+ * version that contains all four commits.
+ */
+
+export const PI_AI_FORWARD_FIX_REQUIRED_VERSION = "0.84.2";
+
+export const PI_AI_FORWARD_FIX_TARGETS = Object.freeze([
+	"dist/api/google-generative-ai.js",
+	"dist/api/google-shared.js",
+	"dist/api/google-vertex.js",
+	"dist/api/bedrock-converse-stream.js",
+	"dist/providers/data/xiaomi.json",
+	"dist/providers/data/xiaomi-token-plan-cn.json",
+	"dist/providers/data/xiaomi-token-plan-ams.json",
+	"dist/providers/data/xiaomi-token-plan-sgp.json",
+	"dist/providers/data/zai.json",
+	"dist/providers/data/zai-coding-cn.json",
+]);
+
+export const PI_AI_FORWARD_FIX_MARKERS = Object.freeze({
+	googleGenerativeAi: "Feynman Pi 0.84.2 forward patch: Google thinking level maps",
+	googleShared: "Feynman Pi 0.84.2 forward patch: resolve Google thinking level maps",
+	googleVertex: "Feynman Pi 0.84.2 forward patch: Vertex thinking level maps",
+	bedrock: "Feynman Pi 0.84.2 forward patch: Bedrock Smithy response headers",
+});
+
+const XIAOMI_DEPRECATED_MODEL_IDS = Object.freeze([
+	"mimo-v2-flash",
+	"mimo-v2-omni",
+	"mimo-v2-pro",
+]);
+
+const ZAI_REFERENCE_COSTS = Object.freeze({
+	"glm-4.7": Object.freeze({ input: 0.6, output: 2.2, cacheRead: 0.11, cacheWrite: 0 }),
+	"glm-5-turbo": Object.freeze({ input: 1.2, output: 4, cacheRead: 0.24, cacheWrite: 0 }),
+	"glm-5.2": Object.freeze({ input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 }),
+});
+
+const ZAI_CHINA_ADDITIONS = Object.freeze({
+	"glm-4.6v": Object.freeze({
+		id: "glm-4.6v",
+		name: "GLM-4.6V",
+		api: "openai-completions",
+		provider: "zai-coding-cn",
+		baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+		reasoning: true,
+		input: Object.freeze(["text", "image"]),
+		cost: Object.freeze({ input: 0.3, output: 0.9, cacheRead: 0, cacheWrite: 0 }),
+		compat: Object.freeze({
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: false,
+			maxTokensField: "max_tokens",
+			thinkingFormat: "zai",
+			zaiToolStream: true,
+		}),
+		contextWindow: 128000,
+		maxTokens: 32768,
+	}),
+	"glm-5.1": Object.freeze({
+		id: "glm-5.1",
+		name: "GLM-5.1",
+		api: "openai-completions",
+		provider: "zai-coding-cn",
+		baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+		reasoning: true,
+		input: Object.freeze(["text"]),
+		cost: Object.freeze({ input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 }),
+		compat: Object.freeze({
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: false,
+			maxTokensField: "max_tokens",
+			thinkingFormat: "zai",
+			zaiToolStream: true,
+		}),
+		contextWindow: 200000,
+		maxTokens: 131072,
+	}),
+	"glm-5v-turbo": Object.freeze({
+		id: "glm-5v-turbo",
+		name: "GLM-5V-Turbo",
+		api: "openai-completions",
+		provider: "zai-coding-cn",
+		baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+		reasoning: true,
+		input: Object.freeze(["text", "image"]),
+		cost: Object.freeze({ input: 1.2, output: 4, cacheRead: 0.24, cacheWrite: 0 }),
+		compat: Object.freeze({
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: false,
+			maxTokensField: "max_tokens",
+			thinkingFormat: "zai",
+			zaiToolStream: true,
+		}),
+		contextWindow: 200000,
+		maxTokens: 131072,
+	}),
+});
+
+function countOccurrences(source, fragment) {
+	return source.split(fragment).length - 1;
+}
+
+function replaceRequired(source, original, replacement, label) {
+	const count = countOccurrences(source, original);
+	if (count !== 1) {
+		throw new Error(
+			`Unsupported Pi ${PI_AI_FORWARD_FIX_REQUIRED_VERSION} ${label} layout; expected 1 occurrence, found ${count}`,
+		);
+	}
+	return source.replace(original, replacement);
+}
+
+function replaceRequiredCount(source, original, replacement, expectedCount, label) {
+	const count = countOccurrences(source, original);
+	if (count !== expectedCount) {
+		throw new Error(
+			`Unsupported Pi ${PI_AI_FORWARD_FIX_REQUIRED_VERSION} ${label} layout; expected ${expectedCount} occurrences, found ${count}`,
+		);
+	}
+	return source.replaceAll(original, replacement);
+}
+
+function deepEqual(left, right) {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function parseCatalog(source, relativePath) {
+	try {
+		const parsed = JSON.parse(source);
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			throw new Error("catalog root is not an object");
+		}
+		return parsed;
+	} catch (error) {
+		throw new Error(`Invalid Pi AI model catalog ${relativePath}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+function getOpenAiModels(catalog, relativePath) {
+	const models = catalog["openai-completions"];
+	if (!models || typeof models !== "object" || Array.isArray(models)) {
+		throw new Error(`Unsupported Pi ${PI_AI_FORWARD_FIX_REQUIRED_VERSION} ${relativePath}: missing openai-completions`);
+	}
+	return models;
+}
+
+function assertXiaomiCatalog(relativePath, catalog) {
+	const models = getOpenAiModels(catalog, relativePath);
+	for (const modelId of XIAOMI_DEPRECATED_MODEL_IDS) {
+		if (modelId in models) {
+			throw new Error(`Incomplete Pi AI Xiaomi catalog patch ${relativePath}: retained ${modelId}`);
+		}
+	}
+	for (const modelId of ["mimo-v2.5", "mimo-v2.5-pro"]) {
+		if (!(modelId in models)) {
+			throw new Error(`Incomplete Pi AI Xiaomi catalog patch ${relativePath}: missing ${modelId}`);
+		}
+	}
+}
+
+function assertZaiCatalog(relativePath, catalog) {
+	const models = getOpenAiModels(catalog, relativePath);
+	for (const [modelId, cost] of Object.entries(ZAI_REFERENCE_COSTS)) {
+		if (!deepEqual(models[modelId]?.cost, cost)) {
+			throw new Error(`Incomplete Pi AI ZAI catalog patch ${relativePath}: incorrect ${modelId} cost`);
+		}
+	}
+	if (relativePath.endsWith("/zai-coding-cn.json")) {
+		for (const [modelId, expected] of Object.entries(ZAI_CHINA_ADDITIONS)) {
+			if (!deepEqual(models[modelId], expected)) {
+				throw new Error(`Incomplete Pi AI China ZAI catalog patch ${relativePath}: incorrect ${modelId}`);
+			}
+		}
+		const modelIds = Object.keys(models);
+		const sortedModelIds = [...modelIds].sort((left, right) => left.localeCompare(right));
+		if (!deepEqual(modelIds, sortedModelIds)) {
+			throw new Error(`Incomplete Pi AI China ZAI catalog patch ${relativePath}: model order differs from upstream`);
+		}
+	}
+}
+
+function patchModelCatalog(relativePath, source) {
+	const catalog = parseCatalog(source, relativePath);
+	const models = getOpenAiModels(catalog, relativePath);
+
+	if (relativePath.includes("/xiaomi")) {
+		for (const modelId of XIAOMI_DEPRECATED_MODEL_IDS) {
+			delete models[modelId];
+		}
+		assertXiaomiCatalog(relativePath, catalog);
+		return JSON.stringify(catalog);
+	}
+
+	if (relativePath.endsWith("/zai.json") || relativePath.endsWith("/zai-coding-cn.json")) {
+		for (const [modelId, cost] of Object.entries(ZAI_REFERENCE_COSTS)) {
+			if (!models[modelId]) {
+				throw new Error(`Unsupported Pi ${PI_AI_FORWARD_FIX_REQUIRED_VERSION} ${relativePath}: missing ${modelId}`);
+			}
+			models[modelId].cost = { ...cost };
+		}
+		if (relativePath.endsWith("/zai-coding-cn.json")) {
+			for (const [modelId, model] of Object.entries(ZAI_CHINA_ADDITIONS)) {
+				models[modelId] = structuredClone(model);
+			}
+			catalog["openai-completions"] = Object.fromEntries(
+				Object.entries(models).sort(([left], [right]) => left.localeCompare(right)),
+			);
+		}
+		assertZaiCatalog(relativePath, catalog);
+		return JSON.stringify(catalog);
+	}
+
+	throw new Error(`Unknown Pi AI model catalog patch target: ${relativePath}`);
+}
+
+function assertSourceFragments(source, relativePath, fragments) {
+	for (const fragment of fragments) {
+		if (!source.includes(fragment)) {
+			throw new Error(`Incomplete Pi AI forward patch ${relativePath}: missing ${fragment}`);
+		}
+	}
+}
+
+export function assertPiAiForwardFixSource(relativePath, source) {
+	if (relativePath.includes("/providers/data/")) {
+		const catalog = parseCatalog(source, relativePath);
+		if (relativePath.includes("/xiaomi")) {
+			assertXiaomiCatalog(relativePath, catalog);
+			return;
+		}
+		assertZaiCatalog(relativePath, catalog);
+		return;
+	}
+
+	switch (relativePath) {
+		case "dist/api/google-generative-ai.js":
+			assertSourceFragments(source, relativePath, [
+				PI_AI_FORWARD_FIX_MARKERS.googleGenerativeAi,
+				"resolveGoogleThinkingLevel(model, clampedReasoning)",
+				"level: getThinkingLevel(resolvedLevel, googleModel)",
+				"budgetTokens: getGoogleBudget(googleModel, resolvedLevel, options.thinkingBudgets)",
+			]);
+			return;
+		case "dist/api/google-shared.js":
+			assertSourceFragments(source, relativePath, [
+				PI_AI_FORWARD_FIX_MARKERS.googleShared,
+				"export function resolveGoogleThinkingLevel(model, level)",
+				"Unsupported Google thinking level mapping",
+			]);
+			return;
+		case "dist/api/google-vertex.js":
+			assertSourceFragments(source, relativePath, [
+				PI_AI_FORWARD_FIX_MARKERS.googleVertex,
+				"resolveGoogleThinkingLevel(model, clampedReasoning)",
+				"level: getGemini3ThinkingLevel(resolvedLevel, geminiModel)",
+				"budgetTokens: getGoogleBudget(geminiModel, resolvedLevel, options.thinkingBudgets)",
+			]);
+			return;
+		case "dist/api/bedrock-converse-stream.js":
+			assertSourceFragments(source, relativePath, [
+				PI_AI_FORWARD_FIX_MARKERS.bedrock,
+				"addResponseHeadersMiddleware(client, options.onResponse, model",
+				"if (!observedRawResponse && response.$metadata.httpStatusCode !== undefined)",
+				'name: "pi-ai-response-headers"',
+			]);
+			return;
+		default:
+			throw new Error(`Unknown Pi AI forward patch target: ${relativePath}`);
+	}
+}
+
+function patchGoogleShared(source) {
+	const relativePath = "dist/api/google-shared.js";
+	if (source.includes(PI_AI_FORWARD_FIX_MARKERS.googleShared)) {
+		assertPiAiForwardFixSource(relativePath, source);
+		return source;
+	}
+	const anchor = 'import { transformMessages } from "./transform-messages.js";';
+	const helper = `${anchor}
+// ${PI_AI_FORWARD_FIX_MARKERS.googleShared}
+export function resolveGoogleThinkingLevel(model, level) {
+    if (level === "off")
+        return "high";
+    const mapped = model.thinkingLevelMap?.[level];
+    const resolvedLevel = typeof mapped === "string" ? mapped.toLowerCase() : level;
+    switch (resolvedLevel) {
+        case "minimal":
+        case "low":
+        case "medium":
+        case "high":
+            return resolvedLevel;
+        default:
+            throw new Error(\`Unsupported Google thinking level mapping for \${model.provider}/\${model.id}: \${level} -> \${String(mapped)}\`);
+    }
+}`;
+	const patched = replaceRequired(source, anchor, helper, "Google shared thinking map");
+	assertPiAiForwardFixSource(relativePath, patched);
+	return patched;
+}
+
+function patchGoogleGenerativeAi(source) {
+	const relativePath = "dist/api/google-generative-ai.js";
+	if (source.includes(PI_AI_FORWARD_FIX_MARKERS.googleGenerativeAi)) {
+		assertPiAiForwardFixSource(relativePath, source);
+		return source;
+	}
+	let patched = replaceRequired(
+		source,
+		'import { convertMessages, convertTools, isThinkingPart, mapStopReason, resolveGoogleFunctionCallingMode, retainThoughtSignature, retryGoogleRequest, supportsGoogleStrictToolSampling, } from "./google-shared.js";',
+		`import { convertMessages, convertTools, isThinkingPart, mapStopReason, resolveGoogleFunctionCallingMode, resolveGoogleThinkingLevel, retainThoughtSignature, retryGoogleRequest, supportsGoogleStrictToolSampling, } from "./google-shared.js";
+// ${PI_AI_FORWARD_FIX_MARKERS.googleGenerativeAi}`,
+		"Google Generative AI import",
+	);
+	patched = replaceRequired(
+		patched,
+		'    const effort = (clampedReasoning === "off" ? "high" : clampedReasoning);',
+		"    const resolvedLevel = resolveGoogleThinkingLevel(model, clampedReasoning);",
+		"Google Generative AI level resolution",
+	);
+	patched = replaceRequired(patched, "level: getThinkingLevel(effort, googleModel)", "level: getThinkingLevel(resolvedLevel, googleModel)", "Google Generative AI thinking level");
+	patched = replaceRequired(patched, "budgetTokens: getGoogleBudget(googleModel, effort, options.thinkingBudgets)", "budgetTokens: getGoogleBudget(googleModel, resolvedLevel, options.thinkingBudgets)", "Google Generative AI thinking budget");
+	patched = replaceRequired(patched, "function getGoogleBudget(model, effort, customBudgets) {", "function getGoogleBudget(model, level, customBudgets) {", "Google Generative AI budget parameter");
+	patched = replaceRequired(patched, "customBudgets?.[effort]", "customBudgets?.[level]", "Google Generative AI custom budget check");
+	patched = replaceRequired(patched, "customBudgets[effort]", "customBudgets[level]", "Google Generative AI custom budget value");
+	patched = replaceRequiredCount(patched, "budgets[effort]", "budgets[level]", 3, "Google Generative AI built-in budgets");
+	assertPiAiForwardFixSource(relativePath, patched);
+	return patched;
+}
+
+function patchGoogleVertex(source) {
+	const relativePath = "dist/api/google-vertex.js";
+	if (source.includes(PI_AI_FORWARD_FIX_MARKERS.googleVertex)) {
+		assertPiAiForwardFixSource(relativePath, source);
+		return source;
+	}
+	let patched = replaceRequired(
+		source,
+		'import { convertMessages, convertTools, isThinkingPart, mapStopReason, resolveGoogleFunctionCallingMode, retainThoughtSignature, retryGoogleRequest, supportsGoogleStrictToolSampling, } from "./google-shared.js";',
+		`import { convertMessages, convertTools, isThinkingPart, mapStopReason, resolveGoogleFunctionCallingMode, resolveGoogleThinkingLevel, retainThoughtSignature, retryGoogleRequest, supportsGoogleStrictToolSampling, } from "./google-shared.js";
+// ${PI_AI_FORWARD_FIX_MARKERS.googleVertex}`,
+		"Google Vertex import",
+	);
+	patched = replaceRequired(
+		patched,
+		'    const effort = (clampedReasoning === "off" ? "high" : clampedReasoning);',
+		"    const resolvedLevel = resolveGoogleThinkingLevel(model, clampedReasoning);",
+		"Google Vertex level resolution",
+	);
+	patched = replaceRequired(patched, "level: getGemini3ThinkingLevel(effort, geminiModel)", "level: getGemini3ThinkingLevel(resolvedLevel, geminiModel)", "Google Vertex thinking level");
+	patched = replaceRequired(patched, "budgetTokens: getGoogleBudget(geminiModel, effort, options.thinkingBudgets)", "budgetTokens: getGoogleBudget(geminiModel, resolvedLevel, options.thinkingBudgets)", "Google Vertex thinking budget");
+	patched = replaceRequired(patched, "function getGoogleBudget(model, effort, customBudgets) {", "function getGoogleBudget(model, level, customBudgets) {", "Google Vertex budget parameter");
+	patched = replaceRequired(patched, "customBudgets?.[effort]", "customBudgets?.[level]", "Google Vertex custom budget check");
+	patched = replaceRequired(patched, "customBudgets[effort]", "customBudgets[level]", "Google Vertex custom budget value");
+	patched = replaceRequiredCount(patched, "budgets[effort]", "budgets[level]", 2, "Google Vertex built-in budgets");
+	assertPiAiForwardFixSource(relativePath, patched);
+	return patched;
+}
+
+function patchBedrock(source) {
+	const relativePath = "dist/api/bedrock-converse-stream.js";
+	if (source.includes(PI_AI_FORWARD_FIX_MARKERS.bedrock)) {
+		assertPiAiForwardFixSource(relativePath, source);
+		return source;
+	}
+	let patched = replaceRequired(
+		source,
+		"            const client = new BedrockRuntimeClient(config);",
+		`            const client = new BedrockRuntimeClient(config);
+            let observedRawResponse = false;
+            if (options.onResponse) {
+                addResponseHeadersMiddleware(client, options.onResponse, model, () => {
+                    observedRawResponse = true;
+                });
+            }`,
+		"Bedrock response middleware registration",
+	);
+	patched = replaceRequired(
+		patched,
+		"            if (response.$metadata.httpStatusCode !== undefined) {",
+		"            if (!observedRawResponse && response.$metadata.httpStatusCode !== undefined) {",
+		"Bedrock metadata fallback",
+	);
+	const anchor = `    client.middlewareStack.add(middleware, { step: "build", name: "pi-ai-custom-headers", priority: "low" });
+}
+export const streamSimple`;
+	const helper = `    client.middlewareStack.add(middleware, { step: "build", name: "pi-ai-custom-headers", priority: "low" });
+}
+// ${PI_AI_FORWARD_FIX_MARKERS.bedrock}
+function isSmithyHttpResponse(response) {
+    if (!response || typeof response !== "object")
+        return false;
+    const candidate = response;
+    return typeof candidate.statusCode === "number" && !!candidate.headers && typeof candidate.headers === "object";
+}
+function toProviderResponse(response) {
+    if (!isSmithyHttpResponse(response))
+        return undefined;
+    return { status: response.statusCode, headers: { ...response.headers } };
+}
+function addResponseHeadersMiddleware(client, onResponse, model, onObserved) {
+    const middleware = (next) => async (args) => {
+        const result = await next(args);
+        const providerResponse = toProviderResponse(result.response);
+        if (providerResponse) {
+            onObserved();
+            await onResponse(providerResponse, model);
+        }
+        return result;
+    };
+    client.middlewareStack.add(middleware, { step: "deserialize", name: "pi-ai-response-headers" });
+}
+export const streamSimple`;
+	patched = replaceRequired(patched, anchor, helper, "Bedrock response middleware");
+	assertPiAiForwardFixSource(relativePath, patched);
+	return patched;
+}
+
+export function patchPiAiForwardFixSource(relativePath, source) {
+	if (relativePath.includes("/providers/data/")) {
+		return patchModelCatalog(relativePath, source);
+	}
+	switch (relativePath) {
+		case "dist/api/google-generative-ai.js":
+			return patchGoogleGenerativeAi(source);
+		case "dist/api/google-shared.js":
+			return patchGoogleShared(source);
+		case "dist/api/google-vertex.js":
+			return patchGoogleVertex(source);
+		case "dist/api/bedrock-converse-stream.js":
+			return patchBedrock(source);
+		default:
+			throw new Error(`Unknown Pi AI forward patch target: ${relativePath}`);
+	}
+}

--- a/scripts/lib/pi-ai-forward-fixes-verifier.mjs
+++ b/scripts/lib/pi-ai-forward-fixes-verifier.mjs
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+	assertPiAiForwardFixSource,
+	PI_AI_FORWARD_FIX_REQUIRED_VERSION,
+	PI_AI_FORWARD_FIX_TARGETS,
+} from "./pi-ai-forward-fixes-patch.mjs";
+
+export function assertPiAiForwardFixCopies(readSource, surface) {
+	for (const relativePath of PI_AI_FORWARD_FIX_TARGETS) {
+		for (const copy of ["root", "nested"]) {
+			try {
+				assertPiAiForwardFixSource(relativePath, readSource(relativePath, copy));
+			} catch (error) {
+				throw new Error(
+					`${surface} ${copy} Pi AI ${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+					{ cause: error },
+				);
+			}
+		}
+	}
+}
+
+export function assertPiAiForwardFixPackageTree(packageRoot, readText) {
+	assertPiAiForwardFixCopies(
+		(relativePath, copy) =>
+			readText(
+				resolve(
+					packageRoot,
+					"node_modules",
+					"@earendil-works",
+					...(copy === "nested"
+						? ["pi-coding-agent", "node_modules", "@earendil-works", "pi-ai"]
+						: ["pi-ai"]),
+					...relativePath.split("/"),
+				),
+				`bundled ${copy} Pi AI ${relativePath}`,
+			),
+		"bundled",
+	);
+	const nestedManifest = JSON.parse(
+		readText(
+			resolve(
+				packageRoot,
+				"node_modules",
+				"@earendil-works",
+				"pi-coding-agent",
+				"node_modules",
+				"@earendil-works",
+				"pi-ai",
+				"package.json",
+			),
+			"bundled nested Pi AI manifest",
+		),
+	);
+	assert.equal(nestedManifest.version, PI_AI_FORWARD_FIX_REQUIRED_VERSION);
+}
+
+export function assertPiAiForwardFixArchive(readEntry) {
+	assertPiAiForwardFixCopies(
+		(relativePath, copy) =>
+			readEntry(
+				copy === "nested"
+					? `npm/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/${relativePath}`
+					: `npm/node_modules/@earendil-works/pi-ai/${relativePath}`,
+			),
+		"runtime archive",
+	);
+	const nestedManifest = JSON.parse(
+		readEntry(
+			"npm/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/package.json",
+		),
+	);
+	assert.equal(nestedManifest.version, PI_AI_FORWARD_FIX_REQUIRED_VERSION);
+}
+
+export async function verifyPiAiForwardFixBehavior(packageRoot) {
+	const piAiRoot = resolve(packageRoot, "node_modules", "@earendil-works", "pi-ai");
+	const nestedPiAiRoot = resolve(
+		packageRoot,
+		"node_modules",
+		"@earendil-works",
+		"pi-coding-agent",
+		"node_modules",
+		"@earendil-works",
+		"pi-ai",
+	);
+	assertPiAiForwardFixCopies(
+		(relativePath, copy) =>
+			readFileSync(
+				resolve(copy === "root" ? piAiRoot : nestedPiAiRoot, ...relativePath.split("/")),
+				"utf8",
+			),
+		"installed",
+	);
+
+	const googleShared = await import(
+		`${pathToFileURL(resolve(piAiRoot, "dist", "api", "google-shared.js")).href}?installed-forward-fix=${Date.now()}`
+	);
+	const googleModel = {
+		id: "gemini-3.7-flash",
+		name: "gemini-3.7-flash",
+		api: "google-generative-ai",
+		provider: "installed-google",
+		baseUrl: "https://example.invalid/v1beta",
+		reasoning: true,
+		thinkingLevelMap: { high: "LOW" },
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	};
+	assert.equal(googleShared.resolveGoogleThinkingLevel(googleModel, "high"), "low");
+
+	const google = await import(
+		`${pathToFileURL(resolve(piAiRoot, "dist", "api", "google-generative-ai.js")).href}?installed-forward-fix=${Date.now()}`
+	);
+	let googlePayload;
+	const googleResult = await google.streamSimple(
+		googleModel,
+		{ messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+		{
+			apiKey: "test",
+			reasoning: "high",
+			onPayload: (payload) => {
+				googlePayload = payload;
+				throw new Error("installed Google payload captured");
+			},
+		},
+	).result();
+	assert.match(googleResult.errorMessage ?? "", /installed Google payload captured/);
+	assert.equal(googlePayload?.config?.thinkingConfig?.thinkingLevel, "LOW");
+
+	const providers = await import(
+		`${pathToFileURL(resolve(piAiRoot, "dist", "providers", "all.js")).href}?installed-forward-fix=${Date.now()}`
+	);
+	for (const provider of [
+		"xiaomi",
+		"xiaomi-token-plan-cn",
+		"xiaomi-token-plan-ams",
+		"xiaomi-token-plan-sgp",
+	]) {
+		const modelIds = providers.getBuiltinModels(provider).map((model) => model.id);
+		for (const id of ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro"]) {
+			assert.equal(modelIds.includes(id), false, `${provider} retained ${id}`);
+		}
+	}
+	assert.deepEqual(providers.getBuiltinModel("zai", "glm-5.2").cost, {
+		input: 1.4,
+		output: 4.4,
+		cacheRead: 0.26,
+		cacheWrite: 0,
+	});
+	for (const id of ["glm-4.6v", "glm-5.1", "glm-5v-turbo"]) {
+		assert.equal(providers.getBuiltinModel("zai-coding-cn", id).id, id);
+	}
+
+	let server;
+	try {
+		const modelId = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+		server = createServer((_request, response) => {
+			response.writeHead(200, {
+				"content-type": "application/vnd.amazon.eventstream",
+				"x-amzn-requestid": "installed-req-123",
+				"x-bifrost-provider": "bedrock",
+				"x-bifrost-resolved-model": modelId,
+			});
+			response.end();
+		});
+		await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+		const address = server.address();
+		assert.ok(address && typeof address !== "string");
+		const bedrock = await import(
+			`${pathToFileURL(resolve(piAiRoot, "dist", "api", "bedrock-converse-stream.js")).href}?installed-forward-fix=${Date.now()}`
+		);
+		const compat = await import(
+			`${pathToFileURL(resolve(piAiRoot, "dist", "compat.js")).href}?installed-forward-fix=${Date.now()}`
+		);
+		const responses = [];
+		const result = await bedrock.stream(
+			{
+				...compat.getModel("amazon-bedrock", modelId),
+				baseUrl: `http://127.0.0.1:${address.port}`,
+			},
+			{ messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
+			{
+				cacheRetention: "none",
+				env: { AWS_BEDROCK_FORCE_HTTP1: "1", AWS_BEDROCK_SKIP_AUTH: "1" },
+				onResponse: (response) => responses.push(response),
+			},
+		).result();
+		assert.equal(result.stopReason, "error");
+		assert.equal(responses.length, 1);
+		assert.equal(responses[0].headers["x-amzn-requestid"], "installed-req-123");
+		assert.equal(responses[0].headers["x-bifrost-provider"], "bedrock");
+		assert.equal(responses[0].headers["x-bifrost-resolved-model"], modelId);
+	} finally {
+		if (server) {
+			await new Promise((resolveClose, rejectClose) => {
+				server.close((error) => (error ? rejectClose(error) : resolveClose()));
+			});
+		}
+	}
+}

--- a/scripts/lib/runtime-workspace-integrity.mjs
+++ b/scripts/lib/runtime-workspace-integrity.mjs
@@ -17,6 +17,7 @@ export const RUNTIME_INPUT_FILES = Object.freeze([
 	".feynman/runtime-package-lock.json",
 	".feynman/settings.json",
 	"scripts/lib/pi-agent-core-patch.mjs",
+	"scripts/lib/pi-ai-forward-fixes-patch.mjs",
 	"scripts/lib/pi-runtime-correctness-patch.mjs",
 	"scripts/lib/pi-llama-usage-patch.mjs",
 	"scripts/lib/pi-extension-loader-patch.mjs",

--- a/scripts/patch-embedded-pi.mjs
+++ b/scripts/patch-embedded-pi.mjs
@@ -10,6 +10,10 @@ import { patchAlphaHubSearchResultsSource, patchAlphaHubSearchSource } from "./l
 import { patchMcpSdkPackageJsonSource } from "./lib/mcp-sdk-package-patch.mjs";
 import { patchPiAgentCoreSource } from "./lib/pi-agent-core-patch.mjs";
 import {
+	PI_AI_FORWARD_FIX_TARGETS,
+	patchPiAiForwardFixSource,
+} from "./lib/pi-ai-forward-fixes-patch.mjs";
+import {
 	assertPiRuntimeCorrectnessVersion,
 	PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION,
 	patchPiAgentSessionSource,
@@ -165,6 +169,12 @@ const githubCopilotOAuthPaths = resolvePiAiRuntimeFiles(
 	"auth",
 	"oauth",
 	"github-copilot.js",
+);
+const piAiForwardFixPaths = PI_AI_FORWARD_FIX_TARGETS.flatMap((relativePath) =>
+	resolvePiAiRuntimeFiles(...relativePath.split("/")).map((entryPath) => ({
+		entryPath,
+		relativePath,
+	}))
 );
 const workspaceAgentLoopPath = resolveWorkspacePiFile("pi-agent-core", "dist", "agent-loop.js");
 const workspaceNestedAgentLoopPaths = resolveWorkspaceNestedPiFiles(
@@ -1007,6 +1017,10 @@ for (const [entryPath, patchSource] of [
 	...githubCopilotOAuthPaths.map((entryPath) => [
 		entryPath,
 		patchPiGithubCopilotOAuthSource,
+	]),
+	...piAiForwardFixPaths.map(({ entryPath, relativePath }) => [
+		entryPath,
+		(source) => patchPiAiForwardFixSource(relativePath, source),
 	]),
 ]) {
 	if (

--- a/scripts/prepare-runtime-workspace.mjs
+++ b/scripts/prepare-runtime-workspace.mjs
@@ -4,6 +4,10 @@ import { spawnSync } from "node:child_process";
 
 import { patchPiAgentCoreSource } from "./lib/pi-agent-core-patch.mjs";
 import {
+	PI_AI_FORWARD_FIX_TARGETS,
+	patchPiAiForwardFixSource,
+} from "./lib/pi-ai-forward-fixes-patch.mjs";
+import {
 	assertPiRuntimeCorrectnessVersion,
 	PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION,
 	patchPiAgentSessionSource,
@@ -567,6 +571,17 @@ function patchBundledPiRuntimeCorrectness() {
 		"dist/auth/oauth/github-copilot.js",
 		patchPiGithubCopilotOAuthSource,
 	) || changed;
+	for (const relativePath of PI_AI_FORWARD_FIX_TARGETS) {
+		changed = patchScopedPiWorkspaceFile(
+			"pi-ai",
+			relativePath,
+			(source) => patchPiAiForwardFixSource(relativePath, source),
+		) || changed;
+		changed = patchBundledNestedPiAiFile(
+			relativePath,
+			(source) => patchPiAiForwardFixSource(relativePath, source),
+		) || changed;
+	}
 	return changed;
 }
 

--- a/scripts/verify-installed-runtime.mjs
+++ b/scripts/verify-installed-runtime.mjs
@@ -24,6 +24,7 @@ import {
 	terminateChildProcessTree,
 } from "./lib/child-process-cleanup.mjs";
 import { resolveChildProcessCommand } from "./lib/child-process-command.mjs";
+import { verifyPiAiForwardFixBehavior } from "./lib/pi-ai-forward-fixes-verifier.mjs";
 
 const EXPECTED_FEYNMAN_COMMANDS = Object.freeze([
 	"capabilities",
@@ -764,6 +765,7 @@ async function main() {
 	await verifyWebAccessRegistrationGates();
 	await verifyInstalledSchemas();
 	await verifyGithubCopilotRateLimitLogin();
+	await verifyPiAiForwardFixBehavior(packageRoot);
 	console.log(JSON.stringify({
 		binary: defaultBinaryPath,
 		commands: EXPECTED_FEYNMAN_COMMANDS.length,
@@ -775,6 +777,7 @@ async function main() {
 		webAccessRegistrationGates: "passed",
 		malformedSubagentIsolation: "passed",
 		githubCopilotRateLimit: "passed",
+		piAiForwardFixes: "passed",
 	}));
 }
 

--- a/scripts/verify-package-artifact.mjs
+++ b/scripts/verify-package-artifact.mjs
@@ -6,6 +6,10 @@ import {
 	assertPiCodingAgentUndiciShrinkwrapSource,
 	FEYNMAN_UNDICI_VERSION,
 } from "./lib/pi-undici-proxy-patch.mjs";
+import {
+	assertPiAiForwardFixArchive,
+	assertPiAiForwardFixPackageTree,
+} from "./lib/pi-ai-forward-fixes-verifier.mjs";
 import { assertPiLlamaUsagePatchSource } from "./lib/pi-llama-usage-patch.mjs";
 import {
 	assertPiRuntimeCorrectnessPatchSource,
@@ -302,23 +306,7 @@ for (const [target, relativePath] of [
 		assertPiRuntimeCorrectnessPatchSource(readText(path, label), target, label);
 	}
 }
-if (
-	readJson(
-		resolve(
-			packageRoot,
-			"node_modules",
-			"@earendil-works",
-			"pi-coding-agent",
-			"node_modules",
-			"@earendil-works",
-			"pi-ai",
-			"package.json",
-		),
-		"bundled nested Pi AI manifest",
-	).version !== PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION
-) {
-	fail(`bundled nested Pi AI is not ${PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION}`);
-}
+assertPiAiForwardFixPackageTree(packageRoot, readText);
 
 requireMarkers(
 	readText(
@@ -686,6 +674,7 @@ for (const [target, relativePath] of [
 		);
 	}
 }
+assertPiAiForwardFixArchive((entryPath) => readArchivedText(archivePath, entryPath));
 for (const [label, entryPath] of [
 	[
 		"runtime root Pi AgentCore",
@@ -701,14 +690,6 @@ for (const [label, entryPath] of [
 		'["search_web", "web_search"]',
 		"prepareToolCallArguments(tool, effectiveToolCall)",
 	]);
-}
-if (
-	readArchivedJson(
-		archivePath,
-		"npm/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/package.json",
-	).version !== PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION
-) {
-	fail(`runtime nested Pi AI is not ${PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION}`);
 }
 for (const name of ["pi-agent-core", "pi-tui"]) {
 	if (

--- a/src/pi/runtime-patches.ts
+++ b/src/pi/runtime-patches.ts
@@ -6,6 +6,10 @@ import { patchAlphaHubSearchResultsSource, patchAlphaHubSearchSource } from "../
 import { patchMcpSdkPackageJsonSource } from "../../scripts/lib/mcp-sdk-package-patch.mjs";
 import { patchPiAgentCoreSource } from "../../scripts/lib/pi-agent-core-patch.mjs";
 import {
+	PI_AI_FORWARD_FIX_TARGETS,
+	patchPiAiForwardFixSource,
+} from "../../scripts/lib/pi-ai-forward-fixes-patch.mjs";
+import {
 	assertPiRuntimeCorrectnessVersion,
 	patchPiAgentSessionSource,
 	patchPiGithubCopilotDeviceCodeSource,
@@ -312,6 +316,23 @@ export function patchPiRuntimeNodeModules(
 			patchPiGithubCopilotOAuthSource,
 			bundledPiVersion,
 		) || changed;
+		for (const relativePath of PI_AI_FORWARD_FIX_TARGETS) {
+			changed = patchScopedPiPackageFileIfPresent(
+				nodeModulesPath,
+				"pi-ai",
+				relativePath,
+				(source) => patchPiAiForwardFixSource(relativePath, source),
+				bundledPiVersion,
+			) || changed;
+			changed = patchNestedPiPackageFileIfPresent(
+				nodeModulesPath,
+				"pi-coding-agent",
+				"pi-ai",
+				relativePath,
+				(source) => patchPiAiForwardFixSource(relativePath, source),
+				bundledPiVersion,
+			) || changed;
+		}
 		changed = patchScopedPiPackageFileIfPresent(
 			nodeModulesPath,
 			"pi-tui",

--- a/tests/pi-ai-forward-fixes-patch.test.ts
+++ b/tests/pi-ai-forward-fixes-patch.test.ts
@@ -1,0 +1,330 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+	assertPiAiForwardFixSource,
+	PI_AI_FORWARD_FIX_MARKERS,
+	PI_AI_FORWARD_FIX_TARGETS,
+	patchPiAiForwardFixSource,
+} from "../scripts/lib/pi-ai-forward-fixes-patch.mjs";
+import { patchPiRuntimeNodeModules } from "../src/pi/runtime-patches.js";
+
+const appRoot = process.cwd();
+patchPiRuntimeNodeModules(appRoot);
+
+const piAiRoot = resolve(appRoot, "node_modules", "@earendil-works", "pi-ai");
+const nestedPiAiRoot = resolve(
+	appRoot,
+	"node_modules",
+	"@earendil-works",
+	"pi-coding-agent",
+	"node_modules",
+	"@earendil-works",
+	"pi-ai",
+);
+
+function readPiAiSource(root: string, relativePath: string): string {
+	return readFileSync(resolve(root, ...relativePath.split("/")), "utf8");
+}
+
+function googleModel(
+	api: "google-generative-ai" | "google-vertex",
+	id: string,
+	thinkingLevelMap: Record<string, string>,
+) {
+	return {
+		id,
+		name: id,
+		api,
+		provider: `test-${api}`,
+		baseUrl: "https://example.invalid/v1",
+		reasoning: true,
+		thinkingLevelMap,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	};
+}
+
+async function captureGooglePayload(
+	modulePath: string,
+	model: ReturnType<typeof googleModel>,
+	reasoning: string,
+	thinkingBudgets?: Record<string, number>,
+) {
+	const provider = await import(`${pathToFileURL(modulePath).href}?forward-fix=${Date.now()}`);
+	let payload: unknown;
+	const result = await provider.streamSimple(
+		model,
+		{ messages: [{ role: "user", content: "Hello", timestamp: 0 }] },
+		{
+			apiKey: "test",
+			reasoning,
+			thinkingBudgets,
+			onPayload: (request: unknown) => {
+				payload = request;
+				throw new Error("payload captured");
+			},
+		},
+	).result();
+	assert.match(result.errorMessage ?? "", /payload captured/);
+	assert.ok(payload, "Google payload was not captured");
+	return payload as {
+		config?: {
+			thinkingConfig?: {
+				thinkingLevel?: string;
+				thinkingBudget?: number;
+			};
+		};
+	};
+}
+
+test("Pi AI forward patch covers root and nested 0.84.2 runtime copies", () => {
+	const patchSource = readFileSync(
+		resolve(appRoot, "scripts", "lib", "pi-ai-forward-fixes-patch.mjs"),
+		"utf8",
+	);
+	for (const commit of ["af2c352", "10acee6", "0e4d495", "8720548"]) {
+		assert.match(patchSource, new RegExp(commit));
+	}
+	assert.match(
+		patchSource,
+		/Removal condition: delete this patch after Feynman adopts a released Pi/,
+	);
+
+	for (const relativePath of PI_AI_FORWARD_FIX_TARGETS) {
+		for (const root of [piAiRoot, nestedPiAiRoot]) {
+			const source = readPiAiSource(root, relativePath);
+			assert.doesNotThrow(() => assertPiAiForwardFixSource(relativePath, source));
+			assert.equal(patchPiAiForwardFixSource(relativePath, source), source);
+		}
+	}
+});
+
+test("Pi AI forward patch applies each unsupported 0.84.2 source layout once", () => {
+	const shared = patchPiAiForwardFixSource(
+		"dist/api/google-shared.js",
+		'import { transformMessages } from "./transform-messages.js";',
+	);
+	assert.match(shared, new RegExp(PI_AI_FORWARD_FIX_MARKERS.googleShared));
+	assert.match(shared, /export function resolveGoogleThinkingLevel/);
+
+	const generative = patchPiAiForwardFixSource(
+		"dist/api/google-generative-ai.js",
+		[
+			'import { convertMessages, convertTools, isThinkingPart, mapStopReason, resolveGoogleFunctionCallingMode, retainThoughtSignature, retryGoogleRequest, supportsGoogleStrictToolSampling, } from "./google-shared.js";',
+			'    const effort = (clampedReasoning === "off" ? "high" : clampedReasoning);',
+			"level: getThinkingLevel(effort, googleModel)",
+			"budgetTokens: getGoogleBudget(googleModel, effort, options.thinkingBudgets)",
+			"function getGoogleBudget(model, effort, customBudgets) {",
+			"customBudgets?.[effort]",
+			"customBudgets[effort]",
+			"budgets[effort]",
+			"budgets[effort]",
+			"budgets[effort]",
+		].join("\n"),
+	);
+	assert.match(generative, new RegExp(PI_AI_FORWARD_FIX_MARKERS.googleGenerativeAi));
+	assert.match(generative, /getThinkingLevel\(resolvedLevel, googleModel\)/);
+	assert.doesNotMatch(generative, /budgets\[effort\]/);
+
+	const vertex = patchPiAiForwardFixSource(
+		"dist/api/google-vertex.js",
+		[
+			'import { convertMessages, convertTools, isThinkingPart, mapStopReason, resolveGoogleFunctionCallingMode, retainThoughtSignature, retryGoogleRequest, supportsGoogleStrictToolSampling, } from "./google-shared.js";',
+			'    const effort = (clampedReasoning === "off" ? "high" : clampedReasoning);',
+			"level: getGemini3ThinkingLevel(effort, geminiModel)",
+			"budgetTokens: getGoogleBudget(geminiModel, effort, options.thinkingBudgets)",
+			"function getGoogleBudget(model, effort, customBudgets) {",
+			"customBudgets?.[effort]",
+			"customBudgets[effort]",
+			"budgets[effort]",
+			"budgets[effort]",
+		].join("\n"),
+	);
+	assert.match(vertex, new RegExp(PI_AI_FORWARD_FIX_MARKERS.googleVertex));
+	assert.match(vertex, /getGemini3ThinkingLevel\(resolvedLevel, geminiModel\)/);
+	assert.doesNotMatch(vertex, /budgets\[effort\]/);
+
+	const bedrock = patchPiAiForwardFixSource(
+		"dist/api/bedrock-converse-stream.js",
+		[
+			"            const client = new BedrockRuntimeClient(config);",
+			"            if (response.$metadata.httpStatusCode !== undefined) {",
+			'    client.middlewareStack.add(middleware, { step: "build", name: "pi-ai-custom-headers", priority: "low" });',
+			"}",
+			"export const streamSimple",
+		].join("\n"),
+	);
+	assert.match(bedrock, new RegExp(PI_AI_FORWARD_FIX_MARKERS.bedrock));
+	assert.match(bedrock, /step: "deserialize", name: "pi-ai-response-headers"/);
+	assert.match(bedrock, /!observedRawResponse/);
+
+	const xiaomi = patchPiAiForwardFixSource(
+		"dist/providers/data/xiaomi.json",
+		JSON.stringify({
+			"openai-completions": {
+				"mimo-v2-flash": { id: "mimo-v2-flash" },
+				"mimo-v2-omni": { id: "mimo-v2-omni" },
+				"mimo-v2-pro": { id: "mimo-v2-pro" },
+				"mimo-v2.5": { id: "mimo-v2.5" },
+				"mimo-v2.5-pro": { id: "mimo-v2.5-pro" },
+			},
+		}),
+	);
+	assert.doesNotMatch(xiaomi, /mimo-v2-flash|mimo-v2-omni|mimo-v2-pro"/);
+	assert.match(xiaomi, /mimo-v2\.5-pro/);
+
+	const zai = patchPiAiForwardFixSource(
+		"dist/providers/data/zai-coding-cn.json",
+		JSON.stringify({
+			"openai-completions": Object.fromEntries(
+				["glm-4.7", "glm-5-turbo", "glm-5.2"].map((id) => [
+					id,
+					{ id, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+				]),
+			),
+		}),
+	);
+	const zaiModels = JSON.parse(zai)["openai-completions"];
+	assert.deepEqual(Object.keys(zaiModels), [
+		"glm-4.6v",
+		"glm-4.7",
+		"glm-5-turbo",
+		"glm-5.1",
+		"glm-5.2",
+		"glm-5v-turbo",
+	]);
+	assert.deepEqual(zaiModels["glm-4.7"].cost, {
+		input: 0.6,
+		output: 2.2,
+		cacheRead: 0.11,
+		cacheWrite: 0,
+	});
+	for (const id of ["glm-4.6v", "glm-5.1", "glm-5v-turbo"]) {
+		assert.equal(zaiModels[id].id, id);
+	}
+});
+
+test("Google providers honor model thinking maps and mapped token budgets", async () => {
+	const shared = await import(
+		`${pathToFileURL(resolve(piAiRoot, "dist", "api", "google-shared.js")).href}?forward-fix=${Date.now()}`
+	);
+	assert.equal(
+		shared.resolveGoogleThinkingLevel(
+			googleModel("google-generative-ai", "gemini-3.7-flash", { high: "LOW" }),
+			"high",
+		),
+		"low",
+	);
+	assert.throws(
+		() =>
+			shared.resolveGoogleThinkingLevel(
+				googleModel("google-generative-ai", "gemini-3.7-flash", { xhigh: "extreme" }),
+				"xhigh",
+			),
+		/Unsupported Google thinking level mapping/,
+	);
+
+	const generativePayload = await captureGooglePayload(
+		resolve(piAiRoot, "dist", "api", "google-generative-ai.js"),
+		googleModel("google-generative-ai", "gemini-3.7-flash", { high: "LOW" }),
+		"high",
+	);
+	assert.equal(generativePayload.config?.thinkingConfig?.thinkingLevel, "LOW");
+
+	const vertexPayload = await captureGooglePayload(
+		resolve(piAiRoot, "dist", "api", "google-vertex.js"),
+		googleModel("google-vertex", "gemini-2.5-flash", { max: "high" }),
+		"max",
+		{ high: 4321 },
+	);
+	assert.equal(vertexPayload.config?.thinkingConfig?.thinkingBudget, 4321);
+});
+
+test("Bedrock forwards raw Smithy response headers to onResponse", async (t) => {
+	let server: Server | undefined;
+	t.after(async () => {
+		if (!server) return;
+		await new Promise<void>((resolveClose, rejectClose) => {
+			server?.close((error) => (error ? rejectClose(error) : resolveClose()));
+		});
+	});
+	const modelId = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+	server = createServer((_request, response) => {
+		response.writeHead(200, {
+			"content-type": "application/vnd.amazon.eventstream",
+			"x-amzn-requestid": "req-123",
+			"x-bifrost-provider": "bedrock",
+			"x-bifrost-resolved-model": modelId,
+		});
+		response.end();
+	});
+	await new Promise<void>((resolveListen) => server?.listen(0, "127.0.0.1", resolveListen));
+	const address = server.address();
+	assert.ok(address && typeof address !== "string");
+
+	const bedrock = await import(
+		`${pathToFileURL(resolve(piAiRoot, "dist", "api", "bedrock-converse-stream.js")).href}?forward-fix=${Date.now()}`
+	);
+	const compat = await import(
+		`${pathToFileURL(resolve(piAiRoot, "dist", "compat.js")).href}?forward-fix=${Date.now()}`
+	);
+	const responses: Array<{ status: number; headers: Record<string, string> }> = [];
+	const model = {
+		...compat.getModel("amazon-bedrock", modelId),
+		baseUrl: `http://127.0.0.1:${address.port}`,
+	};
+	const result = await bedrock.stream(
+		model,
+		{ messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
+		{
+			cacheRetention: "none",
+			env: { AWS_BEDROCK_FORCE_HTTP1: "1", AWS_BEDROCK_SKIP_AUTH: "1" },
+			onResponse: (response: { status: number; headers: Record<string, string> }) => {
+				responses.push(response);
+			},
+		},
+	).result();
+
+	assert.equal(result.stopReason, "error");
+	assert.equal(responses.length, 1);
+	assert.equal(responses[0].status, 200);
+	assert.equal(responses[0].headers["x-amzn-requestid"], "req-123");
+	assert.equal(responses[0].headers["x-bifrost-provider"], "bedrock");
+	assert.equal(responses[0].headers["x-bifrost-resolved-model"], modelId);
+});
+
+test("patched Xiaomi and China ZAI catalogs expose only current provider models", async () => {
+	const providers = await import(
+		`${pathToFileURL(resolve(piAiRoot, "dist", "providers", "all.js")).href}?forward-fix=${Date.now()}`
+	);
+	for (const provider of [
+		"xiaomi",
+		"xiaomi-token-plan-cn",
+		"xiaomi-token-plan-ams",
+		"xiaomi-token-plan-sgp",
+	]) {
+		const modelIds = providers.getBuiltinModels(provider).map((model: { id: string }) => model.id);
+		for (const id of ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2-pro"]) {
+			assert.equal(modelIds.includes(id), false, `${provider} retained ${id}`);
+		}
+		for (const id of ["mimo-v2.5", "mimo-v2.5-pro"]) {
+			assert.equal(modelIds.includes(id), true, `${provider} omitted ${id}`);
+		}
+	}
+	assert.deepEqual(providers.getBuiltinModel("zai", "glm-5.2").cost, {
+		input: 1.4,
+		output: 4.4,
+		cacheRead: 0.26,
+		cacheWrite: 0,
+	});
+	for (const id of ["glm-4.6v", "glm-5.1", "glm-5v-turbo"]) {
+		assert.equal(providers.getBuiltinModel("zai-coding-cn", id).id, id);
+	}
+});

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,23 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.27 - 2026-08-17
+
+### Provider reliability
+
+- Google and Vertex models now honor model-specific thinking-level maps. Extended or remapped levels produce the supported provider level and use its matching token budget.
+- Bedrock gateway response callbacks now receive the raw Smithy response headers. Provider routing and request headers no longer disappear before Feynman can record them.
+
+### Model catalogs
+
+- Removed deprecated Xiaomi MiMo model IDs while keeping the current MiMo 2.5 models across direct and token-plan providers.
+- Added the current China Z.AI Coding Plan models, including GLM-4.6V, GLM-5.1, and GLM-5V-Turbo. Matching API-priced models now report their reference costs.
+
+### Validation
+
+- Backported four focused fixes from Pi after `0.84.2` and applied them to root, nested, packaged, and restored runtime copies.
+- Added direct Google, Vertex, Bedrock, Xiaomi, and Z.AI regressions plus installed-package and archive checks.
+
 ## v0.3.26 - 2026-08-17
 
 ### Document research


### PR DESCRIPTION
## Summary

- forward-port four unreleased Pi provider corrections into the bundled `0.84.2` runtime
- honor Google and Vertex thinking-level maps and preserve mapped token budgets
- forward raw Bedrock Smithy response headers
- remove deprecated Xiaomi IDs and add the current China Z.AI Coding Plan catalog
- apply and verify the removable patch across source, nested, packaged, restored, and archived runtime paths

## Intake disposition

- **port:** Pi `af2c352`, `10acee6`, `0e4d495`, and `8720548`; each fixes current Feynman provider or catalog behavior
- **reject:** Pi `1d08508`; example-only behavior with no shipped Feynman path
- **reject:** Pi `a6b1dbc`; Feynman does not consume the new compaction-failure event
- open Feynman issues and prior pull requests: none

## Verification

Exact head: `7f7d8cfcc6aedbd888f92be585d9b781a390b439`

- focused tests: `27/27`
- full tests: `792/792`
- typecheck, build, architecture check: passed
- website lint, typecheck, and build: passed (`34` pages)
- root, website, runtime, and clean-consumer production audits: zero vulnerabilities
- dry and real local packs matched: `114,844,777` bytes, `298,899,679` unpacked bytes, `29,141` files
- local tarball SHA-256: `2a5705c9f0d89cdf9c499b320388f78584dfb9969bcda3b54ad274ddac64520c`
- clean installed tarball passed artifact, stale-Pi, RPC, TypeBox, provider, and document gates
- Daytona sandbox `87887474-4ab5-4886-9284-9802f5ac73e8` passed the full ladder on Node `25.9.0`
- Daytona dry and real packs matched: `116,549,349` bytes, `300,633,972` unpacked bytes, `29,141` files
- Daytona tarball SHA-256: `ad7f413a9cfa30afd820cb0ff6f25a9eb52eaa634cb8de60108d1816e18c7105`
- the Daytona sandbox is deleted and now returns Not Found

## Release

This updates Feynman to `0.3.27`. Merge only after the exact-head release candidate and consumer matrix pass. The publish workflow must then prove npm, GitHub assets, installers, provenance, and live provider smoke paths.