### PR TITLE
Fix research runtime fallback and Baseten images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-18 03:03 EDT — research-runtime-forward-fixes-0.3.28
+
+- Objective: Port two current upstream corrections that affect Feynman's foreground research-agent runtime without adopting adjacent workflow or provider scope.
+- Intake: Open issues and pull requests are empty. Recent contributor forks add no exclusive research-loop change. Main workflow `32060676201` is green, and npm/GitHub remain `0.3.27` at `d3966b9`. Security alerts and production audits are empty.
+- Reproduced: Bundled `pi-subagents@0.40.0` did not retry `The usage limit has been reached`, although it retried rate-limit and quota failures. Pi `0.84.2` exposed Baseten GLM 5.2 and GLM 5.2 Fast as text-only while the current provider catalog declares text and image inputs.
+- Changed: Forward-ported `pi-subagents` commit `5b4a1dd` and Pi commit `ad58801` through the existing removable runtime patchers. Added focused behavior, root/nested catalog, package-archive, and installed-runtime checks. Updated release notes and version metadata for `0.3.28`.
+- Review repair: An adversarial pass proved the first usage-limit verifier accepted comment-only dead code and found that prior catalog backports left Pi's generated model manifest stale. The verifier now executes the installed TypeScript fallback through Pi's Jiti loader. Every local, nested, archived, and restored catalog copy now verifies all shard hashes and the recomputed model-structure hash.
+- Verified locally: Focused tests passed `30/30`; the full suite passed `793/793`; typecheck, build, architecture, website lint/typecheck/build (`34` pages), source/site/runtime/consumer audits, freshness review, and diff checks passed. Dry and real packs matched within the release budget. A clean installed tarball passed stale-Pi repair, package, `15`-tool/`9`-command RPC, TypeBox, executable runtime-forward-fix, and document parse/search/screenshot/table checks.
+- State: `unverified` for Daytona, exact-head CI, merge, publication, and release identity. Next: commit the exact candidate and finish those release gates.
+
 ### 2026-08-17 15:29 EDT — pi-provider-forward-fixes-0.3.27-release-complete
 
 - Objective: Finish the four Pi provider corrections through exact-head CI, merge, publication, live installers, and terminal intake reconciliation.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,22 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.28 - 2026-08-18
+
+### Research agents
+
+- Delegated research now treats provider subscription usage-limit errors as retryable. Configured fallback models continue instead of ending the run.
+
+### Model inputs
+
+- Baseten GLM 5.2 and GLM 5.2 Fast now accept image inputs. Paper figures and other attached research images reach these models.
+- Pi's model-data manifest now matches every backported catalog shard and its final model structure.
+
+### Validation
+
+- Backported the two focused upstream corrections across local, packaged, restored, and installed runtime copies.
+- Added executable fallback behavior plus complete catalog hash and structure checks across source, package archives, and installed runtimes.
+
 ## v0.3.27 - 2026-08-17
 
 ### Provider reliability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.27",
+      "version": "0.3.28",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/scripts/lib/pi-ai-forward-fixes-patch.mjs
+++ b/scripts/lib/pi-ai-forward-fixes-patch.mjs
@@ -4,9 +4,10 @@
  * - 10acee6045e9025a22dff7e5220ed0d7538f12aa (Bedrock response headers)
  * - 0e4d49541477c4fc6e404f845ad40ed47d157f24 (deprecated Xiaomi models)
  * - 87205484bf749c2140fef5d1bea68995d57e739c (China ZAI catalog)
+ * - ad58801ce793ca4ca2f6fb64b307e9eaffd2c471 (Baseten GLM image inputs)
  *
  * Removal condition: delete this patch after Feynman adopts a released Pi
- * version that contains all four commits.
+ * version that contains all five commits.
  */
 
 export const PI_AI_FORWARD_FIX_REQUIRED_VERSION = "0.84.2";
@@ -22,6 +23,8 @@ export const PI_AI_FORWARD_FIX_TARGETS = Object.freeze([
 	"dist/providers/data/xiaomi-token-plan-sgp.json",
 	"dist/providers/data/zai.json",
 	"dist/providers/data/zai-coding-cn.json",
+	"dist/providers/data/baseten.json",
+	"dist/providers/data/.manifest.json",
 ]);
 
 export const PI_AI_FORWARD_FIX_MARKERS = Object.freeze({
@@ -36,6 +39,23 @@ const XIAOMI_DEPRECATED_MODEL_IDS = Object.freeze([
 	"mimo-v2-omni",
 	"mimo-v2-pro",
 ]);
+
+const BASETEN_IMAGE_MODEL_IDS = Object.freeze([
+	"zai-org/GLM-5.2",
+	"zai-org/GLM-5.2-Fast",
+]);
+
+const PATCHED_MODEL_DATA_STRUCTURE_HASH = "a2a167065a0bd00645b34c52292f2f2b468af195d0d58e15382a3e071ebf94dd";
+
+const PATCHED_MODEL_DATA_FILE_HASHES = Object.freeze({
+	"baseten.json": "245c6ef6381f3d8e9d251857e07585db0aeef4156e8d4c31de31aef12444f2e0",
+	"xiaomi.json": "59826b1eba4cc3d2ad2c7af809f72318eedb797412e5ffd988c7ff88e873d6aa",
+	"xiaomi-token-plan-cn.json": "ec410f4271853b3433080a5237b7d361eced8d1a66387f8b10eb4d0ad127cdf5",
+	"xiaomi-token-plan-ams.json": "1173ec57ebd2b67591b60e8968c176714220689a9ddf21c3fbd928ed76f8635b",
+	"xiaomi-token-plan-sgp.json": "4561b64e163d7c1808872c2c313a2a5dc07d8c974d8eacb4398d2be3b7ccc678",
+	"zai.json": "c21ae231e84e0c3a885c9948008b830f9ea82b9ed552fb3daa548791e7f66f31",
+	"zai-coding-cn.json": "1b53f0c7cd10d8f11bd2cfb177a66ba7e782c3798232e3f9dcf51d83ba8dfe11",
+});
 
 const ZAI_REFERENCE_COSTS = Object.freeze({
 	"glm-4.7": Object.freeze({ input: 0.6, output: 2.2, cacheRead: 0.11, cacheWrite: 0 }),
@@ -189,6 +209,43 @@ function assertZaiCatalog(relativePath, catalog) {
 	}
 }
 
+function assertBasetenCatalog(relativePath, catalog) {
+	const models = getOpenAiModels(catalog, relativePath);
+	for (const modelId of BASETEN_IMAGE_MODEL_IDS) {
+		if (!deepEqual(models[modelId]?.input, ["text", "image"])) {
+			throw new Error(`Incomplete Pi AI Baseten catalog patch ${relativePath}: incorrect ${modelId} input`);
+		}
+	}
+}
+
+function assertModelDataManifest(relativePath, manifest) {
+	if (manifest.schemaVersion !== 3) {
+		throw new Error(`Incomplete Pi AI model manifest patch ${relativePath}: incorrect schema version`);
+	}
+	if (manifest.structureHash !== PATCHED_MODEL_DATA_STRUCTURE_HASH) {
+		throw new Error(`Incomplete Pi AI model manifest patch ${relativePath}: incorrect structure hash`);
+	}
+	if (!manifest.files || typeof manifest.files !== "object" || Array.isArray(manifest.files)) {
+		throw new Error(`Incomplete Pi AI model manifest patch ${relativePath}: missing file hashes`);
+	}
+	for (const [filename, expectedHash] of Object.entries(PATCHED_MODEL_DATA_FILE_HASHES)) {
+		if (manifest.files[filename] !== expectedHash) {
+			throw new Error(`Incomplete Pi AI model manifest patch ${relativePath}: incorrect ${filename} hash`);
+		}
+	}
+}
+
+function patchModelDataManifest(relativePath, source) {
+	const manifest = parseCatalog(source, relativePath);
+	manifest.generatedAt = "2026-08-18T06:19:46.000Z";
+	manifest.structureHash = PATCHED_MODEL_DATA_STRUCTURE_HASH;
+	for (const [filename, expectedHash] of Object.entries(PATCHED_MODEL_DATA_FILE_HASHES)) {
+		manifest.files[filename] = expectedHash;
+	}
+	assertModelDataManifest(relativePath, manifest);
+	return JSON.stringify(manifest);
+}
+
 function patchModelCatalog(relativePath, source) {
 	const catalog = parseCatalog(source, relativePath);
 	const models = getOpenAiModels(catalog, relativePath);
@@ -198,6 +255,17 @@ function patchModelCatalog(relativePath, source) {
 			delete models[modelId];
 		}
 		assertXiaomiCatalog(relativePath, catalog);
+		return JSON.stringify(catalog);
+	}
+
+	if (relativePath.endsWith("/baseten.json")) {
+		for (const modelId of BASETEN_IMAGE_MODEL_IDS) {
+			if (!models[modelId]) {
+				throw new Error(`Unsupported Pi ${PI_AI_FORWARD_FIX_REQUIRED_VERSION} ${relativePath}: missing ${modelId}`);
+			}
+			models[modelId].input = ["text", "image"];
+		}
+		assertBasetenCatalog(relativePath, catalog);
 		return JSON.stringify(catalog);
 	}
 
@@ -234,8 +302,16 @@ function assertSourceFragments(source, relativePath, fragments) {
 export function assertPiAiForwardFixSource(relativePath, source) {
 	if (relativePath.includes("/providers/data/")) {
 		const catalog = parseCatalog(source, relativePath);
+		if (relativePath.endsWith("/.manifest.json")) {
+			assertModelDataManifest(relativePath, catalog);
+			return;
+		}
 		if (relativePath.includes("/xiaomi")) {
 			assertXiaomiCatalog(relativePath, catalog);
+			return;
+		}
+		if (relativePath.endsWith("/baseten.json")) {
+			assertBasetenCatalog(relativePath, catalog);
 			return;
 		}
 		assertZaiCatalog(relativePath, catalog);
@@ -427,6 +503,9 @@ export const streamSimple`;
 
 export function patchPiAiForwardFixSource(relativePath, source) {
 	if (relativePath.includes("/providers/data/")) {
+		if (relativePath.endsWith("/.manifest.json")) {
+			return patchModelDataManifest(relativePath, source);
+		}
 		return patchModelCatalog(relativePath, source);
 	}
 	switch (relativePath) {

--- a/scripts/lib/pi-ai-forward-fixes-verifier.mjs
+++ b/scripts/lib/pi-ai-forward-fixes-verifier.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -9,6 +10,44 @@ import {
 	PI_AI_FORWARD_FIX_REQUIRED_VERSION,
 	PI_AI_FORWARD_FIX_TARGETS,
 } from "./pi-ai-forward-fixes-patch.mjs";
+import {
+	assertPiSubagentPatchedSources,
+	verifyPiSubagentUsageLimitFallbackBehavior,
+} from "./pi-subagents-verification.mjs";
+
+function sortedRecord(entries) {
+	return Object.fromEntries([...entries].sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)));
+}
+
+function sha256(source) {
+	return createHash("sha256").update(source).digest("hex");
+}
+
+function assertPiAiModelDataManifest(readSource, copy, surface) {
+	const manifestPath = "dist/providers/data/.manifest.json";
+	const manifest = JSON.parse(readSource(manifestPath, copy));
+	const structure = [];
+	for (const [filename, expectedHash] of Object.entries(manifest.files ?? {})) {
+		const relativePath = `dist/providers/data/${filename}`;
+		const source = readSource(relativePath, copy);
+		assert.equal(
+			sha256(source),
+			expectedHash,
+			`${surface} ${copy} Pi AI model manifest does not match ${filename}`,
+		);
+		const groups = JSON.parse(source);
+		const models = [];
+		for (const [api, values] of Object.entries(groups)) {
+			for (const modelId of Object.keys(values)) models.push([modelId, api]);
+		}
+		structure.push([filename.slice(0, -".json".length), sortedRecord(models)]);
+	}
+	assert.equal(
+		sha256(JSON.stringify(sortedRecord(structure))),
+		manifest.structureHash,
+		`${surface} ${copy} Pi AI model manifest structure hash is stale`,
+	);
+}
 
 export function assertPiAiForwardFixCopies(readSource, surface) {
 	for (const relativePath of PI_AI_FORWARD_FIX_TARGETS) {
@@ -22,6 +61,9 @@ export function assertPiAiForwardFixCopies(readSource, surface) {
 				);
 			}
 		}
+	}
+	for (const copy of ["root", "nested"]) {
+		assertPiAiModelDataManifest(readSource, copy, surface);
 	}
 }
 
@@ -78,7 +120,15 @@ export function assertPiAiForwardFixArchive(readEntry) {
 	assert.equal(nestedManifest.version, PI_AI_FORWARD_FIX_REQUIRED_VERSION);
 }
 
-export async function verifyPiAiForwardFixBehavior(packageRoot) {
+export async function verifyRuntimeForwardFixBehavior(packageRoot) {
+	assertPiSubagentPatchedSources(
+		(relativePath) => readFileSync(
+			resolve(packageRoot, ".feynman", "npm", "node_modules", "pi-subagents", ...relativePath.split("/")),
+			"utf8",
+		),
+		"installed runtime pi-subagents",
+	);
+	await verifyPiSubagentUsageLimitFallbackBehavior(packageRoot);
 	const piAiRoot = resolve(packageRoot, "node_modules", "@earendil-works", "pi-ai");
 	const nestedPiAiRoot = resolve(
 		packageRoot,
@@ -157,6 +207,9 @@ export async function verifyPiAiForwardFixBehavior(packageRoot) {
 	});
 	for (const id of ["glm-4.6v", "glm-5.1", "glm-5v-turbo"]) {
 		assert.equal(providers.getBuiltinModel("zai-coding-cn", id).id, id);
+	}
+	for (const id of ["zai-org/GLM-5.2", "zai-org/GLM-5.2-Fast"]) {
+		assert.deepEqual(providers.getBuiltinModel("baseten", id).input, ["text", "image"]);
 	}
 
 	let server;

--- a/scripts/lib/pi-subagents-patch.mjs
+++ b/scripts/lib/pi-subagents-patch.mjs
@@ -23,6 +23,7 @@ export const PI_SUBAGENTS_PATCH_TARGETS = [
 	"src/agents/skills.ts",
 	"src/runs/foreground/chain-clarify.ts",
 	"src/runs/shared/pi-spawn.ts",
+	"src/runs/shared/model-fallback.ts",
 	"src/runs/foreground/subagent-executor.ts",
 	"src/extension/schemas.ts",
 ];
@@ -345,6 +346,21 @@ export function patchPiSubagentsSource(relativePath, source) {
 				],
 			]);
 			patched = patchCurrentPiSpawnResolver(patched);
+			break;
+		case "model-fallback.ts":
+			patched = applyReplacementGroup(patched, [[
+				[
+					"const RETRYABLE_MODEL_FAILURE_PATTERNS = [",
+					"\t/rate\\s*limit/i,",
+					"\t/too many requests/i,",
+				].join("\n"),
+				[
+					"const RETRYABLE_MODEL_FAILURE_PATTERNS = [",
+					"\t/rate\\s*limit/i,",
+					"\t/usage\\s*limit/i,",
+					"\t/too many requests/i,",
+				].join("\n"),
+			]]);
 			break;
 		case "subagent-executor.ts":
 			{

--- a/scripts/lib/pi-subagents-verification.d.mts
+++ b/scripts/lib/pi-subagents-verification.d.mts
@@ -1,0 +1,9 @@
+export declare function assertPiSubagentUsageLimitFallbackSource(
+	readSource: (relativePath: string) => string,
+	label: string,
+): void;
+export declare function assertPiSubagentPatchedSources(
+	readSource: (relativePath: string) => string,
+	label?: string,
+): void;
+export declare function verifyPiSubagentUsageLimitFallbackBehavior(packageRoot: string): Promise<void>;

--- a/scripts/lib/pi-subagents-verification.mjs
+++ b/scripts/lib/pi-subagents-verification.mjs
@@ -1,7 +1,42 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
 import { assertPiSubagentAgentDiagnosticsSources } from "./pi-subagents-agent-diagnostics-patch.mjs";
 import { assertPiSubagentPromptMetadataSources } from "./pi-subagents-prompt-metadata-patch.mjs";
+
+const USAGE_LIMIT_FALLBACK_BLOCK = [
+	"const RETRYABLE_MODEL_FAILURE_PATTERNS = [",
+	"\t/rate\\s*limit/i,",
+	"\t/usage\\s*limit/i,",
+	"\t/too many requests/i,",
+].join("\n");
+
+export function assertPiSubagentUsageLimitFallbackSource(readSource, label) {
+	const source = readSource("src/runs/shared/model-fallback.ts");
+	if (!source.includes(USAGE_LIMIT_FALLBACK_BLOCK)) {
+		throw new Error(`${label} model fallback does not retry provider usage-limit errors`);
+	}
+}
 
 export function assertPiSubagentPatchedSources(readSource, label = "pi-subagents") {
 	assertPiSubagentAgentDiagnosticsSources(readSource, label);
 	assertPiSubagentPromptMetadataSources(readSource, label);
+	assertPiSubagentUsageLimitFallbackSource(readSource, label);
+}
+
+export async function verifyPiSubagentUsageLimitFallbackBehavior(packageRoot) {
+	const runtimeRoot = resolve(packageRoot, ".feynman", "npm");
+	const runtimeRequire = createRequire(resolve(runtimeRoot, "package.json"));
+	const jitiEntryPath = runtimeRequire.resolve("jiti");
+	const jitiModule = await import(pathToFileURL(jitiEntryPath).href);
+	assert.equal(typeof jitiModule.createJiti, "function", "Installed Pi Jiti has no createJiti");
+	const jiti = jitiModule.createJiti(import.meta.url, { moduleCache: false });
+	const fallback = await jiti.import(
+		resolve(runtimeRoot, "node_modules", "pi-subagents", "src", "runs", "shared", "model-fallback.ts"),
+	);
+	assert.equal(typeof fallback.isRetryableModelFailure, "function");
+	assert.equal(fallback.isRetryableModelFailure("The usage limit has been reached"), true);
+	assert.equal(fallback.isRetryableModelFailure("research-tools failed with exit code 1"), false);
 }

--- a/scripts/verify-installed-runtime.mjs
+++ b/scripts/verify-installed-runtime.mjs
@@ -24,7 +24,7 @@ import {
 	terminateChildProcessTree,
 } from "./lib/child-process-cleanup.mjs";
 import { resolveChildProcessCommand } from "./lib/child-process-command.mjs";
-import { verifyPiAiForwardFixBehavior } from "./lib/pi-ai-forward-fixes-verifier.mjs";
+import { verifyRuntimeForwardFixBehavior } from "./lib/pi-ai-forward-fixes-verifier.mjs";
 
 const EXPECTED_FEYNMAN_COMMANDS = Object.freeze([
 	"capabilities",
@@ -765,7 +765,7 @@ async function main() {
 	await verifyWebAccessRegistrationGates();
 	await verifyInstalledSchemas();
 	await verifyGithubCopilotRateLimitLogin();
-	await verifyPiAiForwardFixBehavior(packageRoot);
+	await verifyRuntimeForwardFixBehavior(packageRoot);
 	console.log(JSON.stringify({
 		binary: defaultBinaryPath,
 		commands: EXPECTED_FEYNMAN_COMMANDS.length,
@@ -777,7 +777,7 @@ async function main() {
 		webAccessRegistrationGates: "passed",
 		malformedSubagentIsolation: "passed",
 		githubCopilotRateLimit: "passed",
-		piAiForwardFixes: "passed",
+		runtimeForwardFixes: "passed",
 	}));
 }
 

--- a/tests/pi-ai-forward-fixes-patch.test.ts
+++ b/tests/pi-ai-forward-fixes-patch.test.ts
@@ -89,7 +89,7 @@ test("Pi AI forward patch covers root and nested 0.84.2 runtime copies", () => {
 		resolve(appRoot, "scripts", "lib", "pi-ai-forward-fixes-patch.mjs"),
 		"utf8",
 	);
-	for (const commit of ["af2c352", "10acee6", "0e4d495", "8720548"]) {
+	for (const commit of ["af2c352", "10acee6", "0e4d495", "8720548", "ad58801"]) {
 		assert.match(patchSource, new RegExp(commit));
 	}
 	assert.match(
@@ -209,6 +209,47 @@ test("Pi AI forward patch applies each unsupported 0.84.2 source layout once", (
 	for (const id of ["glm-4.6v", "glm-5.1", "glm-5v-turbo"]) {
 		assert.equal(zaiModels[id].id, id);
 	}
+
+	const baseten = patchPiAiForwardFixSource(
+		"dist/providers/data/baseten.json",
+		JSON.stringify({
+			"openai-completions": Object.fromEntries(
+				["zai-org/GLM-5.2", "zai-org/GLM-5.2-Fast"].map((id) => [
+					id,
+					{ id, input: ["text"] },
+				]),
+			),
+		}),
+	);
+	const basetenModels = JSON.parse(baseten)["openai-completions"];
+	for (const id of ["zai-org/GLM-5.2", "zai-org/GLM-5.2-Fast"]) {
+		assert.deepEqual(basetenModels[id].input, ["text", "image"]);
+	}
+
+	const manifest = JSON.parse(
+		patchPiAiForwardFixSource(
+			"dist/providers/data/.manifest.json",
+			JSON.stringify({
+				schemaVersion: 3,
+				generatedAt: "2026-08-14T10:02:30.583Z",
+				structureHash: "stale",
+				files: {
+					"baseten.json": "stale",
+					"xiaomi.json": "stale",
+					"xiaomi-token-plan-cn.json": "stale",
+					"xiaomi-token-plan-ams.json": "stale",
+					"xiaomi-token-plan-sgp.json": "stale",
+					"zai.json": "stale",
+					"zai-coding-cn.json": "stale",
+				},
+			}),
+		),
+	);
+	assert.equal(manifest.structureHash, "a2a167065a0bd00645b34c52292f2f2b468af195d0d58e15382a3e071ebf94dd");
+	assert.equal(
+		manifest.files["baseten.json"],
+		"245c6ef6381f3d8e9d251857e07585db0aeef4156e8d4c31de31aef12444f2e0",
+	);
 });
 
 test("Google providers honor model thinking maps and mapped token budgets", async () => {
@@ -326,5 +367,8 @@ test("patched Xiaomi and China ZAI catalogs expose only current provider models"
 	});
 	for (const id of ["glm-4.6v", "glm-5.1", "glm-5v-turbo"]) {
 		assert.equal(providers.getBuiltinModel("zai-coding-cn", id).id, id);
+	}
+	for (const id of ["zai-org/GLM-5.2", "zai-org/GLM-5.2-Fast"]) {
+		assert.deepEqual(providers.getBuiltinModel("baseten", id).input, ["text", "image"]);
 	}
 });

--- a/tests/pi-subagents-patch.test.ts
+++ b/tests/pi-subagents-patch.test.ts
@@ -2,6 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { PI_SUBAGENTS_PATCH_TARGETS, patchPiSubagentsSource, stripPiSubagentBuiltinModelSource } from "../scripts/lib/pi-subagents-patch.mjs";
+import {
+	assertPiSubagentUsageLimitFallbackSource,
+} from "../scripts/lib/pi-subagents-verification.mjs";
 
 function assertUserDirLoadsHaveDeclaration(source: string): void {
 	for (const chunk of source.split(/\n(?=export function |function )/)) {
@@ -111,10 +114,42 @@ test("PI_SUBAGENTS_PATCH_TARGETS covers current pi-subagents source paths", () =
 			"src/agents/skills.ts",
 			"src/runs/foreground/chain-clarify.ts",
 			"src/runs/shared/pi-spawn.ts",
+			"src/runs/shared/model-fallback.ts",
 			"src/runs/foreground/subagent-executor.ts",
 			"src/extension/schemas.ts",
 		].filter((entry) => !PI_SUBAGENTS_PATCH_TARGETS.includes(entry)),
 		[],
+	);
+});
+
+test("patchPiSubagentsSource retries provider subscription usage limits", async () => {
+	const input = [
+		"const RETRYABLE_MODEL_FAILURE_PATTERNS = [",
+		"\t/rate\\s*limit/i,",
+		"\t/too many requests/i,",
+		"];",
+	].join("\n");
+	const patched = patchPiSubagentsSource("src/runs/shared/model-fallback.ts", input);
+
+	assert.ok(patched.includes("/usage\\s*limit/i"));
+	assert.equal(patchPiSubagentsSource("src/runs/shared/model-fallback.ts", patched), patched);
+
+	const executable = [
+		patched,
+		"export function isRetryableModelFailure(error) {",
+		"\treturn RETRYABLE_MODEL_FAILURE_PATTERNS.some((pattern) => pattern.test(error));",
+		"}",
+	].join("\n");
+	const patchedModule = await import(`data:text/javascript,${encodeURIComponent(executable)}`);
+	assert.equal(patchedModule.isRetryableModelFailure("The usage limit has been reached"), true);
+	assert.equal(patchedModule.isRetryableModelFailure("ordinary tool failure"), false);
+
+	assert.throws(
+		() => assertPiSubagentUsageLimitFallbackSource(
+			() => `// /usage\\\\s*limit/i\n${input}`,
+			"comment-only pi-subagents",
+		),
+		/does not retry provider usage-limit errors/,
 	);
 });
 

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,22 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.28 - 2026-08-18
+
+### Research agents
+
+- Delegated research now treats provider subscription usage-limit errors as retryable. Configured fallback models continue instead of ending the run.
+
+### Model inputs
+
+- Baseten GLM 5.2 and GLM 5.2 Fast now accept image inputs. Paper figures and other attached research images reach these models.
+- Pi's model-data manifest now matches every backported catalog shard and its final model structure.
+
+### Validation
+
+- Backported the two focused upstream corrections across local, packaged, restored, and installed runtime copies.
+- Added executable fallback behavior plus complete catalog hash and structure checks across source, package archives, and installed runtimes.
+
 ## v0.3.27 - 2026-08-17
 
 ### Provider reliability


### PR DESCRIPTION
## Summary

- retry provider subscription usage-limit failures through configured research-agent fallback models
- enable Baseten GLM 5.2 image inputs
- keep every patched Pi model-data shard and manifest hash consistent
- execute the installed fallback implementation during runtime verification

## Verification

- focused tests: 30/30
- full tests: 793/793
- typecheck, build, architecture check
- website lint, typecheck, and 34-page build
- root, website, runtime, extracted-runtime, and consumer audits: 0 vulnerabilities
- dry and real package archives match
- installed package, stale-Pi, RPC, TypeBox, runtime-forward, and document checks pass
- exact SHA `57eff6a919574705dd52fcdce9986929849ba853` passed the same ladder in Daytona on Node 25.9.0
