### PR TITLE
fix: restore working star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,11 @@ Built on [Pi](https://github.com/badlogic/pi-mono) for the agent runtime, [alpha
 
 ### Star History
 
-<a href="https://www.star-history.com/?repos=companion-inc%2Ffeynman&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#companion-inc/feynman&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=companion-inc/feynman&type=date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=companion-inc/feynman&type=date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=companion-inc/feynman&type=date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=companion-inc/feynman&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=companion-inc/feynman&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=companion-inc/feynman&type=date&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the previous provider relies on GitHub stargazer API access that is no longer available. This change points the chart at an alternative that needs no API key, so the image renders correctly for visitors. The repository owner in the chart URLs was also verified against the current remote origin.