### PR TITLE
fix: pace concurrent NCBI research requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,5 @@ MODAL_TOKEN_SECRET=
 
 # Raises the NCBI E-utilities limit from 3 to 10 requests/sec.
 NCBI_API_KEY=
+# Optional minimum delay between NCBI request starts (500ms anonymous, 125ms keyed).
+NCBI_MIN_REQUEST_GAP_MS=

--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,6 @@ AZURE_OPENAI_API_KEY=
 RUNPOD_API_KEY=
 MODAL_TOKEN_ID=
 MODAL_TOKEN_SECRET=
+
+# Raises the NCBI E-utilities limit from 3 to 10 requests/sec.
+NCBI_API_KEY=

--- a/extensions/research-tools/ncbi-rate-limit.ts
+++ b/extensions/research-tools/ncbi-rate-limit.ts
@@ -7,7 +7,8 @@
 
 // Empirical and deliberately under the published ceilings: 400ms anonymous still
 // let a live burst through, because two starts can fall inside one rolling
-// second from either side of a boundary.
+// second from either side of a boundary. Shared or institutional IPs may need
+// more room, so NCBI_MIN_REQUEST_GAP_MS overrides the anonymous interval.
 const ANONYMOUS_MIN_GAP_MS = 500;
 const API_KEY_MIN_GAP_MS = 125;
 const NCBI_HOSTS = new Set(["eutils.ncbi.nlm.nih.gov", "pmc.ncbi.nlm.nih.gov"]);
@@ -22,6 +23,8 @@ let lastStartedAt = Number.NEGATIVE_INFINITY;
 // Paced from what the request carries rather than from the environment, so a
 // caller that does not attach the key is still paced at the anonymous rate.
 function minGapMs(url: URL): number {
+	const override = Number(process.env.NCBI_MIN_REQUEST_GAP_MS);
+	if (Number.isFinite(override) && override >= 0) return override;
 	return url.searchParams.has("api_key") ? API_KEY_MIN_GAP_MS : ANONYMOUS_MIN_GAP_MS;
 }
 
@@ -32,9 +35,9 @@ export function withNcbiRateLimit<T>(url: URL, start: () => Promise<T>): Promise
 		if (wait > 0) await new Promise((resolve) => setTimeout(resolve, wait));
 		lastStartedAt = performance.now();
 	});
-	// The queue holds only the waits, so a slow request never blocks a later
-	// start and a failed one never stalls the queue.
-	chain = slot.catch(() => {});
+	// The queue holds only the waits, never the requests, so a slow or failed
+	// request cannot stall a later start: start runs on the branch below.
+	chain = slot;
 	return slot.then(start);
 }
 

--- a/extensions/research-tools/ncbi-rate-limit.ts
+++ b/extensions/research-tools/ncbi-rate-limit.ts
@@ -1,0 +1,22 @@
+// NCBI limits E-utilities to 3 requests/sec/IP, or 10 with an API key. Pi runs
+// sibling tool calls from one assistant message concurrently, so a single
+// research turn can burst well past that and take 429 responses on most of it.
+//
+// This gate spaces out request starts. It delays when a request begins, not how
+// long it may run, so concurrent calls still overlap on the wire.
+
+const ANONYMOUS_MIN_GAP_MS = 500;
+const API_KEY_MIN_GAP_MS = 125;
+const NCBI_HOSTS = new Set(["eutils.ncbi.nlm.nih.gov", "pmc.ncbi.nlm.nih.gov"]);
+
+let nextStartAt = 0;
+
+export function withNcbiRateLimit<T>(url: URL, start: () => Promise<T>): Promise<T> {
+	if (!NCBI_HOSTS.has(url.hostname)) return start();
+	const now = performance.now();
+	const startAt = Math.max(now, nextStartAt);
+	// Paced from what the request carries rather than from the environment, so a
+	// caller that does not attach the key is still paced at the anonymous rate.
+	nextStartAt = startAt + (url.searchParams.has("api_key") ? API_KEY_MIN_GAP_MS : ANONYMOUS_MIN_GAP_MS);
+	return new Promise((resolve) => setTimeout(resolve, startAt - now)).then(start);
+}

--- a/extensions/research-tools/ncbi-rate-limit.ts
+++ b/extensions/research-tools/ncbi-rate-limit.ts
@@ -5,18 +5,41 @@
 // This gate spaces out request starts. It delays when a request begins, not how
 // long it may run, so concurrent calls still overlap on the wire.
 
+// Empirical and deliberately under the published ceilings: 400ms anonymous still
+// let a live burst through, because two starts can fall inside one rolling
+// second from either side of a boundary.
 const ANONYMOUS_MIN_GAP_MS = 500;
 const API_KEY_MIN_GAP_MS = 125;
 const NCBI_HOSTS = new Set(["eutils.ncbi.nlm.nih.gov", "pmc.ncbi.nlm.nih.gov"]);
 
-let nextStartAt = 0;
+// Each waiter measures from the previous request's ACTUAL start, read when its
+// turn comes up. Reserving absolute wake times upfront looks simpler and still
+// collapses: one long tick leaves every reservation overdue, and the whole burst
+// then starts at once.
+let chain: Promise<void> = Promise.resolve();
+let lastStartedAt = Number.NEGATIVE_INFINITY;
+
+// Paced from what the request carries rather than from the environment, so a
+// caller that does not attach the key is still paced at the anonymous rate.
+function minGapMs(url: URL): number {
+	return url.searchParams.has("api_key") ? API_KEY_MIN_GAP_MS : ANONYMOUS_MIN_GAP_MS;
+}
 
 export function withNcbiRateLimit<T>(url: URL, start: () => Promise<T>): Promise<T> {
 	if (!NCBI_HOSTS.has(url.hostname)) return start();
-	const now = performance.now();
-	const startAt = Math.max(now, nextStartAt);
-	// Paced from what the request carries rather than from the environment, so a
-	// caller that does not attach the key is still paced at the anonymous rate.
-	nextStartAt = startAt + (url.searchParams.has("api_key") ? API_KEY_MIN_GAP_MS : ANONYMOUS_MIN_GAP_MS);
-	return new Promise((resolve) => setTimeout(resolve, startAt - now)).then(start);
+	const slot = chain.then(async () => {
+		const wait = lastStartedAt + minGapMs(url) - performance.now();
+		if (wait > 0) await new Promise((resolve) => setTimeout(resolve, wait));
+		lastStartedAt = performance.now();
+	});
+	// The queue holds only the waits, so a slow request never blocks a later
+	// start and a failed one never stalls the queue.
+	chain = slot.catch(() => {});
+	return slot.then(start);
+}
+
+/** Test seam: drop the recorded schedule so cases do not inherit each other's spacing. */
+export function resetNcbiRateLimitForTests(): void {
+	chain = Promise.resolve();
+	lastStartedAt = Number.NEGATIVE_INFINITY;
 }

--- a/extensions/research-tools/science-database-omics-archives.ts
+++ b/extensions/research-tools/science-database-omics-archives.ts
@@ -1,3 +1,5 @@
+import { withNcbiRateLimit } from "./ncbi-rate-limit.js";
+
 type SearchParams = { limit?: number; query: string; source: string };
 
 const DEFAULT_LIMIT = 5;
@@ -60,7 +62,13 @@ function splitTerms(value: string): string[] {
 		.filter(Boolean);
 }
 
+// NCBI shares one per-IP E-utilities budget across every module, so these
+// requests join the same queue. Non-NCBI hosts return immediately.
 async function fetchJson(url: URL, init?: RequestInit): Promise<unknown> {
+	return withNcbiRateLimit(url, () => fetchJsonDirect(url, init));
+}
+
+async function fetchJsonDirect(url: URL, init?: RequestInit): Promise<unknown> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 	try {
@@ -80,7 +88,13 @@ async function fetchJson(url: URL, init?: RequestInit): Promise<unknown> {
 	}
 }
 
+// NCBI shares one per-IP E-utilities budget across every module, so these
+// requests join the same queue. Non-NCBI hosts return immediately.
 async function fetchJsonWithHeaders(url: URL, init?: RequestInit): Promise<{ headers: Headers; payload: unknown }> {
+	return withNcbiRateLimit(url, () => fetchJsonWithHeadersDirect(url, init));
+}
+
+async function fetchJsonWithHeadersDirect(url: URL, init?: RequestInit): Promise<{ headers: Headers; payload: unknown }> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 	try {

--- a/extensions/research-tools/science-database-pubmed.ts
+++ b/extensions/research-tools/science-database-pubmed.ts
@@ -17,6 +17,13 @@ const DEFAULT_LIMIT = 5;
 const MAX_LIMIT = 20;
 const REQUEST_TIMEOUT_MS = 25_000;
 
+let requestTimeoutMs = REQUEST_TIMEOUT_MS;
+
+/** Test seam: shorten the request budget so timeout cases need not wait 25s. */
+export function setRequestTimeoutForTests(ms: number): void {
+	requestTimeoutMs = ms > 0 ? ms : REQUEST_TIMEOUT_MS;
+}
+
 type QueryOptions = Record<string, string>;
 type CitationInput = {
 	author?: string;
@@ -94,7 +101,7 @@ function prune<T extends Record<string, unknown>>(record: T): Record<string, unk
 async function send<T>(url: URL, accept: string, read: (response: Response) => Promise<T>): Promise<T> {
 	return withNcbiRateLimit(url, async () => {
 		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+		const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
 		try {
 			const response = await fetch(url, {
 				headers: {

--- a/extensions/research-tools/science-database-pubmed.ts
+++ b/extensions/research-tools/science-database-pubmed.ts
@@ -89,41 +89,51 @@ function prune<T extends Record<string, unknown>>(record: T): Record<string, unk
 	return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
 }
 
-async function send(url: URL, accept: string): Promise<Response> {
+// The abort timer stays armed across the body read: fetch resolves on headers,
+// so clearing it earlier would leave a stalled body hanging forever.
+async function send<T>(url: URL, accept: string, read: (response: Response) => Promise<T>): Promise<T> {
 	return withNcbiRateLimit(url, async () => {
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 		try {
-			return await fetch(url, {
+			const response = await fetch(url, {
 				headers: {
 					accept,
 					"user-agent": "feynman-pubmed-tools/1.0 (https://github.com/companion-ai/feynman)",
 				},
 				signal: controller.signal,
 			});
+			return await read(response);
 		} finally {
 			clearTimeout(timeout);
 		}
 	});
 }
 
-async function fetchJson(url: URL): Promise<Record<string, unknown>> {
-	const response = await send(url, "application/json");
+function assertOk(response: Response): void {
 	if (!response.ok) throw new Error(`PubMed request failed: ${response.status} ${response.statusText}`);
-	return recordValue(await response.json());
+}
+
+async function fetchJson(url: URL): Promise<Record<string, unknown>> {
+	return send(url, "application/json", async (response) => {
+		assertOk(response);
+		return recordValue(await response.json());
+	});
 }
 
 async function fetchText(url: URL, accept = "application/xml,text/xml,text/plain,*/*"): Promise<string> {
-	const response = await send(url, accept);
-	if (!response.ok) throw new Error(`PubMed request failed: ${response.status} ${response.statusText}`);
-	return response.text();
+	return send(url, accept, async (response) => {
+		assertOk(response);
+		return response.text();
+	});
 }
 
 async function fetchOptionalText(url: URL, accept = "application/xml,text/xml,*/*"): Promise<{ status: number; text?: string }> {
-	const response = await send(url, accept);
-	if (response.status === 404) return { status: 404 };
-	if (!response.ok) throw new Error(`PubMed request failed: ${response.status} ${response.statusText}`);
-	return { status: response.status, text: await response.text() };
+	return send(url, accept, async (response) => {
+		if (response.status === 404) return { status: 404 };
+		assertOk(response);
+		return { status: response.status, text: await response.text() };
+	});
 }
 
 function queryOptions(query: string): QueryOptions {

--- a/extensions/research-tools/science-database-pubmed.ts
+++ b/extensions/research-tools/science-database-pubmed.ts
@@ -1,4 +1,5 @@
 import { copyrightFromPubmedXml, parseFullTextXml, parsePubmedArticles } from "./science-database-pubmed-parsers.js";
+import { withNcbiRateLimit } from "./ncbi-rate-limit.js";
 
 export type PubMedSearchParams = {
 	limit?: number;
@@ -60,6 +61,18 @@ function cleanQuery(query: string): string {
 
 function ncbiIdentityParams(): Record<string, string> {
 	const email = process.env.NCBI_EMAIL?.trim();
+	const apiKey = process.env.NCBI_API_KEY?.trim();
+	return {
+		tool: "feynman",
+		...(email ? { email } : {}),
+		...(apiKey ? { api_key: apiKey } : {}),
+	};
+}
+
+// The PMC ID Converter is a separate service that documents no api_key support,
+// so it gets identity params without the key.
+function pmcIdentityParams(): Record<string, string> {
+	const email = process.env.NCBI_EMAIL?.trim();
 	return {
 		tool: "feynman",
 		...(email ? { email } : {}),
@@ -76,59 +89,41 @@ function prune<T extends Record<string, unknown>>(record: T): Record<string, unk
 	return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
 }
 
+async function send(url: URL, accept: string): Promise<Response> {
+	return withNcbiRateLimit(url, async () => {
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+		try {
+			return await fetch(url, {
+				headers: {
+					accept,
+					"user-agent": "feynman-pubmed-tools/1.0 (https://github.com/companion-ai/feynman)",
+				},
+				signal: controller.signal,
+			});
+		} finally {
+			clearTimeout(timeout);
+		}
+	});
+}
+
 async function fetchJson(url: URL): Promise<Record<string, unknown>> {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-	try {
-		const response = await fetch(url, {
-			headers: {
-				accept: "application/json",
-				"user-agent": "feynman-pubmed-tools/1.0 (https://github.com/companion-ai/feynman)",
-			},
-			signal: controller.signal,
-		});
-		if (!response.ok) throw new Error(`PubMed request failed: ${response.status} ${response.statusText}`);
-		return recordValue(await response.json());
-	} finally {
-		clearTimeout(timeout);
-	}
+	const response = await send(url, "application/json");
+	if (!response.ok) throw new Error(`PubMed request failed: ${response.status} ${response.statusText}`);
+	return recordValue(await response.json());
 }
 
 async function fetchText(url: URL, accept = "application/xml,text/xml,text/plain,*/*"): Promise<string> {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-	try {
-		const response = await fetch(url, {
-			headers: {
-				accept,
-				"user-agent": "feynman-pubmed-tools/1.0 (https://github.com/companion-ai/feynman)",
-			},
-			signal: controller.signal,
-		});
-		if (!response.ok) throw new Error(`PubMed request failed: ${response.status} ${response.statusText}`);
-		return response.text();
-	} finally {
-		clearTimeout(timeout);
-	}
+	const response = await send(url, accept);
+	if (!response.ok) throw new Error(`PubMed request failed: ${response.status} ${response.statusText}`);
+	return response.text();
 }
 
 async function fetchOptionalText(url: URL, accept = "application/xml,text/xml,*/*"): Promise<{ status: number; text?: string }> {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-	try {
-		const response = await fetch(url, {
-			headers: {
-				accept,
-				"user-agent": "feynman-pubmed-tools/1.0 (https://github.com/companion-ai/feynman)",
-			},
-			signal: controller.signal,
-		});
-		if (response.status === 404) return { status: 404 };
-		if (!response.ok) throw new Error(`PubMed request failed: ${response.status} ${response.statusText}`);
-		return { status: response.status, text: await response.text() };
-	} finally {
-		clearTimeout(timeout);
-	}
+	const response = await send(url, accept);
+	if (response.status === 404) return { status: 404 };
+	if (!response.ok) throw new Error(`PubMed request failed: ${response.status} ${response.statusText}`);
+	return { status: response.status, text: await response.text() };
 }
 
 function queryOptions(query: string): QueryOptions {
@@ -325,7 +320,7 @@ async function convertArticleIds(params: PubMedSearchParams): Promise<Record<str
 		ids: ids.slice(0, MAX_LIMIT).join(","),
 		format: "json",
 		idtype: idType,
-		...ncbiIdentityParams(),
+		...pmcIdentityParams(),
 	}).toString();
 	const payload = await fetchJson(url);
 	const records = listValue(payload.records).map((item) => {
@@ -481,7 +476,7 @@ async function copyrightStatus(params: PubMedSearchParams): Promise<Record<strin
 		ids: pmids.slice(0, MAX_LIMIT).join(","),
 		format: "json",
 		idtype: "pmid",
-		...ncbiIdentityParams(),
+		...pmcIdentityParams(),
 	}).toString();
 	endpoints.push(scrubEndpoint(idconvUrl.toString()));
 	const idconv = await fetchJson(idconvUrl);

--- a/extensions/research-tools/science-database-specialty.ts
+++ b/extensions/research-tools/science-database-specialty.ts
@@ -17,6 +17,7 @@ import { isResearchResourceScienceDatabaseSource, searchResearchResourceScienceD
 import { isUcscScienceDatabaseSource, searchUcsc, type UcscScienceDatabaseSource } from "./science-database-ucsc.js";
 import { isUniBindScienceDatabaseSource, searchUniBind, type UniBindScienceDatabaseSource } from "./science-database-unibind.js";
 import { isZincScienceDatabaseSource, searchZinc, type ZincScienceDatabaseSource } from "./science-database-zinc.js";
+import { withNcbiRateLimit } from "./ncbi-rate-limit.js";
 
 type SearchParams = { limit?: number; query: string; source: SpecialtyScienceDatabaseSource };
 
@@ -108,7 +109,13 @@ function ncbiIdentityParams(): Record<string, string> {
 	};
 }
 
+// NCBI shares one per-IP E-utilities budget across every module, so these
+// requests join the same queue. Non-NCBI hosts return immediately.
 async function fetchJson(url: URL, init?: RequestInit): Promise<unknown> {
+	return withNcbiRateLimit(url, () => fetchJsonDirect(url, init));
+}
+
+async function fetchJsonDirect(url: URL, init?: RequestInit): Promise<unknown> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 	try {
@@ -129,7 +136,13 @@ async function fetchJson(url: URL, init?: RequestInit): Promise<unknown> {
 	}
 }
 
+// NCBI shares one per-IP E-utilities budget across every module, so these
+// requests join the same queue. Non-NCBI hosts return immediately.
 async function fetchJsonWithHeaders(url: URL, init?: RequestInit): Promise<{ headers: Headers; payload: unknown }> {
+	return withNcbiRateLimit(url, () => fetchJsonWithHeadersDirect(url, init));
+}
+
+async function fetchJsonWithHeadersDirect(url: URL, init?: RequestInit): Promise<{ headers: Headers; payload: unknown }> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 	try {

--- a/extensions/research-tools/science-database-variants.ts
+++ b/extensions/research-tools/science-database-variants.ts
@@ -1,3 +1,5 @@
+import { withNcbiRateLimit } from "./ncbi-rate-limit.js";
+
 type SearchParams = {
 	limit?: number;
 	query: string;
@@ -62,7 +64,13 @@ function ncbiIdentityParams(): Record<string, string> {
 	};
 }
 
+// NCBI shares one per-IP E-utilities budget across every module, so these
+// requests join the same queue. Non-NCBI hosts return immediately.
 async function fetchJson(url: URL, init?: RequestInit): Promise<unknown> {
+	return withNcbiRateLimit(url, () => fetchJsonDirect(url, init));
+}
+
+async function fetchJsonDirect(url: URL, init?: RequestInit): Promise<unknown> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 	try {

--- a/scripts/ncbi-burst-check.mjs
+++ b/scripts/ncbi-burst-check.mjs
@@ -1,0 +1,47 @@
+// Reproduces the PubMed 429 burst and measures the fix.
+//
+//   node --import tsx scripts/ncbi-burst-check.mjs
+//   NCBI_API_KEY= node --import tsx scripts/ncbi-burst-check.mjs   # anonymous
+//
+// Issues 12 concurrent feynman_science_database_search calls, the shape of one
+// /lit turn. Each search-mode call makes two E-utilities requests (esearch then
+// esummary), so this is 24 HTTP requests against a 3/sec/IP limit.
+//
+// Run it on main to see the failure, and on the fix to see it go away.
+import { registerScienceDatabaseTools } from "../extensions/research-tools/science-databases.js";
+
+const QUERIES = [
+	"CRISPR base editing", "prime editing", "AAV delivery", "cytosine base editor",
+	"adenine base editor", "epigenome editing", "pegRNA design", "base editing trial",
+	"Cas9 specificity", "dCas9 repression", "gene therapy editing", "off-target detection",
+];
+
+const tools = new Map();
+registerScienceDatabaseTools({ registerTool: (tool) => tools.set(tool.name, tool) });
+const tool = tools.get("feynman_science_database_search");
+
+const startedAt = Date.now();
+const settled = await Promise.allSettled(
+	QUERIES.map((query, i) => tool.execute(`burst-${i}`, { source: "pubmed", query, limit: 3 })),
+);
+
+let ok = 0;
+let rateLimited = 0;
+let other = 0;
+let records = 0;
+for (const outcome of settled) {
+	if (outcome.status === "fulfilled") {
+		ok += 1;
+		records += outcome.value?.details?.returned ?? 0;
+		continue;
+	}
+	const message = String(outcome.reason?.message ?? outcome.reason);
+	if (message.includes("429")) rateLimited += 1;
+	else { other += 1; console.log(`  other failure: ${message.slice(0, 100)}`); }
+}
+
+console.log(
+	`${ok}/${QUERIES.length} calls ok, ${rateLimited} rate-limited, ${other} other, ` +
+	`${records} records, ${Date.now() - startedAt}ms, ` +
+	`key ${process.env.NCBI_API_KEY?.trim() ? "set" : "unset"}`,
+);

--- a/tests/science-database-pubmed-rate-limit.test.ts
+++ b/tests/science-database-pubmed-rate-limit.test.ts
@@ -3,6 +3,7 @@ import { afterEach, test } from "node:test";
 
 import { registerScienceDatabaseTools } from "../extensions/research-tools/science-databases.js";
 import { resetNcbiRateLimitForTests, withNcbiRateLimit } from "../extensions/research-tools/ncbi-rate-limit.js";
+import { setRequestTimeoutForTests } from "../extensions/research-tools/science-database-pubmed.js";
 
 type Tool = {
 	execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; details: unknown }>;
@@ -17,6 +18,7 @@ afterEach(() => {
 	if (originalApiKey === undefined) delete process.env.NCBI_API_KEY;
 	else process.env.NCBI_API_KEY = originalApiKey;
 	resetNcbiRateLimitForTests();
+	setRequestTimeoutForTests(0);
 });
 
 function registerTools(): Map<string, Tool> {
@@ -142,8 +144,9 @@ test("the PMC ID Converter is never sent the NCBI API key", async () => {
 });
 
 test("the request timeout covers the response body, not just the headers", async () => {
-	// fetch resolves once headers arrive, so clearing the abort timer at that
-	// point leaves a stalled body hanging forever.
+	// fetch resolves once headers arrive. Clearing the abort timer at that point
+	// leaves a stalled body hanging forever, which is the regression this covers.
+	setRequestTimeoutForTests(300);
 	globalThis.fetch = async (_input, init) => {
 		const signal = (init as RequestInit | undefined)?.signal;
 		assert.ok(signal, "expected an abort signal on the request");
@@ -157,12 +160,40 @@ test("the request timeout covers the response body, not just the headers", async
 
 	const tool = registerTools().get("feynman_science_database_search");
 	assert.ok(tool);
+	// Race a deadline so a regression fails the case instead of wedging the run.
 	const outcome = await Promise.race([
-		tool.execute("t", { source: "pubmed", query: "crispr", limit: 1 }).then(() => "resolved", () => "failed"),
-		new Promise((resolve) => setTimeout(() => resolve("hanging"), 800)),
+		tool.execute("t", { source: "pubmed", query: "crispr", limit: 1 }).then(() => "resolved", () => "aborted"),
+		new Promise((resolve) => setTimeout(() => resolve("hung"), 3_000)),
 	]);
-	// It must not resolve with a body it never received. Still pending here is
-	// fine: the real budget is REQUEST_TIMEOUT_MS, and the point of this case is
-	// that the signal is still attached while the body is read.
-	assert.notEqual(outcome, "resolved");
+	assert.equal(outcome, "aborted", "the stalled body was never aborted within the request budget");
+});
+
+test("every NCBI module shares one queue, not just PubMed", async () => {
+	// The budget is per-IP, so gating PubMed alone leaves a mixed turn over the
+	// ceiling: ClinVar and GEO hit the same host from their own modules.
+	process.env.NCBI_API_KEY = "test-ncbi-key";
+	resetNcbiRateLimitForTests();
+	const eutilsStarts: number[] = [];
+	globalThis.fetch = async (input) => {
+		const url = String(input instanceof Request ? input.url : input);
+		if (url.includes("eutils.ncbi.nlm.nih.gov")) eutilsStarts.push(performance.now());
+		if (url.includes("/esearch.fcgi")) return esearch();
+		if (url.includes("/esummary.fcgi")) return esummary();
+		return jsonResponse({ esearchresult: { count: "0", idlist: [] }, result: {}, header: {} });
+	};
+
+	const tool = registerTools().get("feynman_science_database_search");
+	assert.ok(tool);
+	await Promise.allSettled([
+		tool.execute("p1", { source: "pubmed", query: "crispr", limit: 1 }),
+		tool.execute("c1", { source: "clinvar", query: "APOE rs7412", limit: 1 }),
+		tool.execute("c2", { source: "clinvar", query: "TP53 variant", limit: 1 }),
+	]);
+
+	assert.ok(eutilsStarts.length >= 3, `expected several E-utilities requests, saw ${eutilsStarts.length}`);
+	const ordered = [...eutilsStarts].sort((a, b) => a - b);
+	for (let i = 1; i < ordered.length; i += 1) {
+		const gap = ordered[i]! - ordered[i - 1]!;
+		assert.ok(gap >= 100, `an ungated module bypassed the queue (${gap.toFixed(0)}ms gap)`);
+	}
 });

--- a/tests/science-database-pubmed-rate-limit.test.ts
+++ b/tests/science-database-pubmed-rate-limit.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { registerScienceDatabaseTools } from "../extensions/research-tools/science-databases.js";
+import { withNcbiRateLimit } from "../extensions/research-tools/ncbi-rate-limit.js";
+
+type Tool = {
+	execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; details: unknown }>;
+	name: string;
+};
+
+const originalFetch = globalThis.fetch;
+const originalNcbiEmail = process.env.NCBI_EMAIL;
+const originalNcbiApiKey = process.env.NCBI_API_KEY;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	if (originalNcbiEmail === undefined) delete process.env.NCBI_EMAIL;
+	else process.env.NCBI_EMAIL = originalNcbiEmail;
+	if (originalNcbiApiKey === undefined) delete process.env.NCBI_API_KEY;
+	else process.env.NCBI_API_KEY = originalNcbiApiKey;
+});
+
+function registerTools(): Map<string, Tool> {
+	const tools = new Map<string, Tool>();
+	registerScienceDatabaseTools({
+		registerTool(tool: Tool) {
+			tools.set(tool.name, tool);
+		},
+	} as never);
+	return tools;
+}
+
+function jsonResponse(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function esearchResponse(): Response {
+	return jsonResponse({
+		esearchresult: {
+			count: "1",
+			idlist: ["35486828"],
+			querytranslation: "crispr[All Fields]",
+		},
+	});
+}
+
+function esummaryResponse(): Response {
+	return jsonResponse({
+		result: {
+			"35486828": {
+				title: "Programmable gene editing example.",
+				fulljournalname: "Nature",
+				pubdate: "2022 Apr 14",
+				authors: [{ name: "Doudna J" }],
+				articleids: [{ idtype: "doi", value: "10.1038/example" }],
+				pubtype: ["Journal Article"],
+			},
+		},
+	});
+}
+
+test("PubMed search sends NCBI_API_KEY when set and redacts it from reported endpoints", async () => {
+	process.env.NCBI_API_KEY = "test-ncbi-key";
+	const requests: string[] = [];
+	globalThis.fetch = async (input) => {
+		const url = String(input instanceof Request ? input.url : input);
+		requests.push(url);
+		if (url.includes("/esearch.fcgi")) return esearchResponse();
+		if (url.includes("/esummary.fcgi")) return esummaryResponse();
+		throw new Error(`unexpected URL ${url}`);
+	};
+
+	const tool = registerTools().get("feynman_science_database_search");
+	assert.ok(tool);
+	const result = await tool.execute("pubmed-api-key", {
+		source: "pubmed",
+		query: "crispr gene editing",
+		limit: 1,
+	});
+
+	const eutilsRequests = requests.filter((url) => url.includes(".fcgi"));
+	assert.equal(eutilsRequests.length, 2);
+	for (const url of eutilsRequests) {
+		assert.equal(new URL(url).searchParams.get("api_key"), "test-ncbi-key");
+	}
+	const details = result.details as { provenance: { endpoints: string[] }; returned: number };
+	assert.equal(details.returned, 1);
+	for (const endpoint of details.provenance.endpoints) {
+		assert.ok(!endpoint.includes("test-ncbi-key"), `endpoint leaks api key: ${endpoint}`);
+	}
+});
+
+test("concurrent NCBI requests are spaced by the shared rate limiter", async () => {
+	process.env.NCBI_API_KEY = "test-ncbi-key";
+	const startTimes: number[] = [];
+	globalThis.fetch = async (input) => {
+		const url = String(input instanceof Request ? input.url : input);
+		startTimes.push(Date.now());
+		if (url.includes("/esearch.fcgi")) return esearchResponse();
+		if (url.includes("/esummary.fcgi")) return esummaryResponse();
+		throw new Error(`unexpected URL ${url}`);
+	};
+
+	const tool = registerTools().get("feynman_science_database_search");
+	assert.ok(tool);
+	await Promise.all(
+		Array.from({ length: 4 }, (_, i) =>
+			tool.execute(`burst-${i}`, { source: "pubmed", query: `topic ${i}`, limit: 1 })),
+	);
+
+	assert.ok(startTimes.length >= 4, `expected at least 4 requests, saw ${startTimes.length}`);
+	const ordered = [...startTimes].sort((a, b) => a - b);
+	for (let i = 1; i < ordered.length; i += 1) {
+		const gap = ordered[i]! - ordered[i - 1]!;
+		assert.ok(gap >= 100, `requests ${i - 1} and ${i} were only ${gap}ms apart`);
+	}
+});
+
+test("non-NCBI hosts bypass the NCBI rate limiter", async () => {
+	const started: number[] = [];
+	await Promise.all(
+		Array.from({ length: 5 }, () =>
+			withNcbiRateLimit(new URL("https://www.ebi.ac.uk/europepmc/webservices/rest/search"), async () => {
+				started.push(Date.now());
+			})),
+	);
+	assert.equal(started.length, 5);
+	const span = Math.max(...started) - Math.min(...started);
+	assert.ok(span < 90, `Europe PMC calls were serialized by the NCBI gate (${span}ms span)`);
+});
+
+test("the PMC ID Converter is not sent the NCBI API key", async () => {
+	// The ID Converter is a separate service that documents no api_key support,
+	// and its URL reaches provenance, so the key must never be attached there.
+	process.env.NCBI_API_KEY = "test-ncbi-key";
+	const requests: string[] = [];
+	globalThis.fetch = async (input) => {
+		const url = String(input instanceof Request ? input.url : input);
+		requests.push(url);
+		if (url.includes("idconv")) {
+			return jsonResponse({
+				status: "ok",
+				records: [{ "requested-id": "35486828", pmid: "35486828", pmcid: "PMC9046468" }],
+			});
+		}
+		throw new Error(`unexpected URL ${url}`);
+	};
+
+	const tool = registerTools().get("feynman_science_database_search");
+	assert.ok(tool);
+	const result = await tool.execute("idconv-key", { source: "pubmed", query: "convert:35486828", limit: 1 });
+
+	const idconv = requests.find((url) => url.includes("idconv"));
+	assert.ok(idconv, "expected an ID Converter request");
+	assert.equal(new URL(idconv).searchParams.get("api_key"), null);
+	for (const endpoint of (result.details as { provenance: { endpoints: string[] } }).provenance.endpoints) {
+		assert.ok(!endpoint.includes("test-ncbi-key"), `endpoint leaks api key: ${endpoint}`);
+	}
+});

--- a/tests/science-database-pubmed-rate-limit.test.ts
+++ b/tests/science-database-pubmed-rate-limit.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 
 import { registerScienceDatabaseTools } from "../extensions/research-tools/science-databases.js";
-import { withNcbiRateLimit } from "../extensions/research-tools/ncbi-rate-limit.js";
+import { resetNcbiRateLimitForTests, withNcbiRateLimit } from "../extensions/research-tools/ncbi-rate-limit.js";
 
 type Tool = {
 	execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; details: unknown }>;
@@ -10,15 +10,13 @@ type Tool = {
 };
 
 const originalFetch = globalThis.fetch;
-const originalNcbiEmail = process.env.NCBI_EMAIL;
-const originalNcbiApiKey = process.env.NCBI_API_KEY;
+const originalApiKey = process.env.NCBI_API_KEY;
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
-	if (originalNcbiEmail === undefined) delete process.env.NCBI_EMAIL;
-	else process.env.NCBI_EMAIL = originalNcbiEmail;
-	if (originalNcbiApiKey === undefined) delete process.env.NCBI_API_KEY;
-	else process.env.NCBI_API_KEY = originalNcbiApiKey;
+	if (originalApiKey === undefined) delete process.env.NCBI_API_KEY;
+	else process.env.NCBI_API_KEY = originalApiKey;
+	resetNcbiRateLimitForTests();
 });
 
 function registerTools(): Map<string, Tool> {
@@ -32,132 +30,139 @@ function registerTools(): Map<string, Tool> {
 }
 
 function jsonResponse(body: unknown): Response {
-	return new Response(JSON.stringify(body), {
-		status: 200,
-		headers: { "content-type": "application/json" },
-	});
+	return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
 }
 
-function esearchResponse(): Response {
-	return jsonResponse({
-		esearchresult: {
-			count: "1",
-			idlist: ["35486828"],
-			querytranslation: "crispr[All Fields]",
-		},
-	});
+const esearch = () => jsonResponse({ esearchresult: { count: "1", idlist: ["35486828"] } });
+const esummary = () => jsonResponse({
+	result: { "35486828": { title: "Example.", fulljournalname: "Nature", pubdate: "2022", authors: [{ name: "Doudna J" }], articleids: [] } },
+});
+
+/** Start `count` gated requests at once and return the gap between consecutive starts. */
+async function measureGaps(url: URL, count: number, blockMs = 0): Promise<number[]> {
+	resetNcbiRateLimitForTests();
+	const starts: number[] = [];
+	const all = Array.from({ length: count }, () =>
+		withNcbiRateLimit(url, async () => { starts.push(performance.now()); }));
+	if (blockMs > 0) {
+		const until = Date.now() + blockMs;
+		while (Date.now() < until) { /* wedge the event loop */ }
+	}
+	await Promise.all(all);
+	return starts.slice(1).map((value, i) => value - starts[i]!);
 }
 
-function esummaryResponse(): Response {
-	return jsonResponse({
-		result: {
-			"35486828": {
-				title: "Programmable gene editing example.",
-				fulljournalname: "Nature",
-				pubdate: "2022 Apr 14",
-				authors: [{ name: "Doudna J" }],
-				articleids: [{ idtype: "doi", value: "10.1038/example" }],
-				pubtype: ["Journal Article"],
-			},
-		},
-	});
-}
+const KEYED = new URL("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&api_key=k");
+const ANON = new URL("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed");
+const IDCONV = new URL("https://pmc.ncbi.nlm.nih.gov/tools/idconv/api/v1/articles/?ids=1");
+const EUROPE_PMC = new URL("https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=x");
 
-test("PubMed search sends NCBI_API_KEY when set and redacts it from reported endpoints", async () => {
+test("keyed NCBI requests are spaced at the keyed rate", async () => {
+	const gaps = await measureGaps(KEYED, 4);
+	for (const gap of gaps) assert.ok(gap >= 120, `expected >=120ms spacing, saw ${gap.toFixed(0)}ms`);
+});
+
+test("unkeyed NCBI requests are spaced at the wider anonymous rate", async () => {
+	const gaps = await measureGaps(ANON, 3);
+	for (const gap of gaps) assert.ok(gap >= 480, `expected >=480ms spacing, saw ${gap.toFixed(0)}ms`);
+});
+
+test("the PMC ID Converter host is rate limited too", async () => {
+	const gaps = await measureGaps(IDCONV, 3);
+	for (const gap of gaps) assert.ok(gap >= 480, `ID Converter was not gated, saw ${gap.toFixed(0)}ms`);
+});
+
+test("spacing survives a blocked event loop", async () => {
+	// Reserving absolute wake times upfront passes every other test here and
+	// still collapses into a single burst once one tick runs long.
+	const gaps = await measureGaps(KEYED, 5, 600);
+	for (const gap of gaps) assert.ok(gap >= 120, `burst collapsed after a stall, saw ${gap.toFixed(0)}ms`);
+});
+
+test("non-NCBI hosts are not delayed by the NCBI budget", async () => {
+	resetNcbiRateLimitForTests();
+	const started: number[] = [];
+	await Promise.all(Array.from({ length: 5 }, () =>
+		withNcbiRateLimit(EUROPE_PMC, async () => { started.push(performance.now()); })));
+	assert.equal(started.length, 5);
+	const span = Math.max(...started) - Math.min(...started);
+	assert.ok(span < 80, `Europe PMC was serialized by the NCBI gate (${span.toFixed(0)}ms span)`);
+});
+
+test("a failed request does not stall the queue", async () => {
+	resetNcbiRateLimitForTests();
+	await assert.rejects(withNcbiRateLimit(KEYED, async () => { throw new Error("boom"); }), /boom/);
+	assert.equal(await withNcbiRateLimit(KEYED, async () => "recovered"), "recovered");
+});
+
+test("PubMed search sends NCBI_API_KEY and keeps it out of reported endpoints", async () => {
 	process.env.NCBI_API_KEY = "test-ncbi-key";
 	const requests: string[] = [];
 	globalThis.fetch = async (input) => {
 		const url = String(input instanceof Request ? input.url : input);
 		requests.push(url);
-		if (url.includes("/esearch.fcgi")) return esearchResponse();
-		if (url.includes("/esummary.fcgi")) return esummaryResponse();
+		if (url.includes("/esearch.fcgi")) return esearch();
+		if (url.includes("/esummary.fcgi")) return esummary();
 		throw new Error(`unexpected URL ${url}`);
 	};
 
 	const tool = registerTools().get("feynman_science_database_search");
 	assert.ok(tool);
-	const result = await tool.execute("pubmed-api-key", {
-		source: "pubmed",
-		query: "crispr gene editing",
-		limit: 1,
-	});
+	const result = await tool.execute("k", { source: "pubmed", query: "crispr", limit: 1 });
 
-	const eutilsRequests = requests.filter((url) => url.includes(".fcgi"));
-	assert.equal(eutilsRequests.length, 2);
-	for (const url of eutilsRequests) {
-		assert.equal(new URL(url).searchParams.get("api_key"), "test-ncbi-key");
-	}
-	const details = result.details as { provenance: { endpoints: string[] }; returned: number };
-	assert.equal(details.returned, 1);
-	for (const endpoint of details.provenance.endpoints) {
-		assert.ok(!endpoint.includes("test-ncbi-key"), `endpoint leaks api key: ${endpoint}`);
+	assert.equal(requests.length, 2, "expected esearch then esummary");
+	for (const url of requests) assert.equal(new URL(url).searchParams.get("api_key"), "test-ncbi-key");
+	const endpoints = (result.details as { provenance: { endpoints: string[] } }).provenance.endpoints;
+	assert.ok(endpoints.length > 0, "expected reported endpoints");
+	for (const endpoint of endpoints) {
+		assert.ok(!endpoint.includes("test-ncbi-key"), `endpoint leaks the key: ${endpoint}`);
+		assert.match(endpoint, /api_key=%5Bredacted%5D/);
 	}
 });
 
-test("concurrent NCBI requests are spaced by the shared rate limiter", async () => {
-	process.env.NCBI_API_KEY = "test-ncbi-key";
-	const startTimes: number[] = [];
-	globalThis.fetch = async (input) => {
-		const url = String(input instanceof Request ? input.url : input);
-		startTimes.push(Date.now());
-		if (url.includes("/esearch.fcgi")) return esearchResponse();
-		if (url.includes("/esummary.fcgi")) return esummaryResponse();
-		throw new Error(`unexpected URL ${url}`);
-	};
-
-	const tool = registerTools().get("feynman_science_database_search");
-	assert.ok(tool);
-	await Promise.all(
-		Array.from({ length: 4 }, (_, i) =>
-			tool.execute(`burst-${i}`, { source: "pubmed", query: `topic ${i}`, limit: 1 })),
-	);
-
-	assert.ok(startTimes.length >= 4, `expected at least 4 requests, saw ${startTimes.length}`);
-	const ordered = [...startTimes].sort((a, b) => a - b);
-	for (let i = 1; i < ordered.length; i += 1) {
-		const gap = ordered[i]! - ordered[i - 1]!;
-		assert.ok(gap >= 100, `requests ${i - 1} and ${i} were only ${gap}ms apart`);
-	}
-});
-
-test("non-NCBI hosts bypass the NCBI rate limiter", async () => {
-	const started: number[] = [];
-	await Promise.all(
-		Array.from({ length: 5 }, () =>
-			withNcbiRateLimit(new URL("https://www.ebi.ac.uk/europepmc/webservices/rest/search"), async () => {
-				started.push(Date.now());
-			})),
-	);
-	assert.equal(started.length, 5);
-	const span = Math.max(...started) - Math.min(...started);
-	assert.ok(span < 90, `Europe PMC calls were serialized by the NCBI gate (${span}ms span)`);
-});
-
-test("the PMC ID Converter is not sent the NCBI API key", async () => {
-	// The ID Converter is a separate service that documents no api_key support,
-	// and its URL reaches provenance, so the key must never be attached there.
+test("the PMC ID Converter is never sent the NCBI API key", async () => {
 	process.env.NCBI_API_KEY = "test-ncbi-key";
 	const requests: string[] = [];
 	globalThis.fetch = async (input) => {
 		const url = String(input instanceof Request ? input.url : input);
 		requests.push(url);
 		if (url.includes("idconv")) {
-			return jsonResponse({
-				status: "ok",
-				records: [{ "requested-id": "35486828", pmid: "35486828", pmcid: "PMC9046468" }],
-			});
+			return jsonResponse({ status: "ok", records: [{ "requested-id": "35486828", pmid: "35486828", pmcid: "PMC9046468" }] });
 		}
 		throw new Error(`unexpected URL ${url}`);
 	};
 
 	const tool = registerTools().get("feynman_science_database_search");
 	assert.ok(tool);
-	const result = await tool.execute("idconv-key", { source: "pubmed", query: "convert:35486828", limit: 1 });
+	await tool.execute("c", { source: "pubmed", query: "convert:35486828", limit: 1 });
 
 	const idconv = requests.find((url) => url.includes("idconv"));
 	assert.ok(idconv, "expected an ID Converter request");
 	assert.equal(new URL(idconv).searchParams.get("api_key"), null);
-	for (const endpoint of (result.details as { provenance: { endpoints: string[] } }).provenance.endpoints) {
-		assert.ok(!endpoint.includes("test-ncbi-key"), `endpoint leaks api key: ${endpoint}`);
-	}
+});
+
+test("the request timeout covers the response body, not just the headers", async () => {
+	// fetch resolves once headers arrive, so clearing the abort timer at that
+	// point leaves a stalled body hanging forever.
+	globalThis.fetch = async (_input, init) => {
+		const signal = (init as RequestInit | undefined)?.signal;
+		assert.ok(signal, "expected an abort signal on the request");
+		const stalled = new ReadableStream({
+			start(controller) {
+				signal.addEventListener("abort", () => controller.error(new Error("aborted")));
+			},
+		});
+		return new Response(stalled, { status: 200, headers: { "content-type": "application/json" } });
+	};
+
+	const tool = registerTools().get("feynman_science_database_search");
+	assert.ok(tool);
+	const outcome = await Promise.race([
+		tool.execute("t", { source: "pubmed", query: "crispr", limit: 1 }).then(() => "resolved", () => "failed"),
+		new Promise((resolve) => setTimeout(() => resolve("hanging"), 800)),
+	]);
+	// It must not resolve with a body it never received. Still pending here is
+	// fine: the real budget is REQUEST_TIMEOUT_MS, and the point of this case is
+	// that the signal is still attached while the body is read.
+	assert.notEqual(outcome, "resolved");
 });

--- a/website/src/content/docs/getting-started/configuration.md
+++ b/website/src/content/docs/getting-started/configuration.md
@@ -154,6 +154,8 @@ Feynman respects the following environment variables, which take precedence over
 | `AWS_PROFILE` | Preferred AWS profile for Amazon Bedrock |
 | `TAVILY_API_KEY` | Tavily web search API key |
 | `SERPER_API_KEY` | Serper web search API key |
+| `NCBI_API_KEY` | Optional NCBI E-utilities key; raises the paced request budget from 3 to 10 requests per second |
+| `NCBI_MIN_REQUEST_GAP_MS` | Override the minimum delay between NCBI request starts; defaults to 500 ms anonymously and 125 ms with a key |
 | `FEYNMAN_TELEMETRY` | Set to `off` to disable Feynman analytics, logs, and traces |
 | `FEYNMAN_POSTHOG_HOST` | Override the PostHog ingest host |
 | `FEYNMAN_POSTHOG_PROJECT_ID` | Override the PostHog project ID used in telemetry metadata |


### PR DESCRIPTION
## Summary

- pace every NCBI E-utilities caller through one process-wide request-start queue
- forward `NCBI_API_KEY` to E-utilities while redacting it from provenance
- keep PubMed timeouts armed through response-body reads
- document the keyed and shared-IP pacing settings

This ports the three exact code commits from #238 onto a maintainer-owned branch, then adds the missing public configuration documentation. It preserves contributor authorship on the code commits.

Closes #237.
Supersedes #238 after this branch passes maintainer CI.

## Verified

- official NCBI policy: 3 requests/sec without a key, 10 requests/sec with a key
- live anonymous 12-search burst on `main`: `0/12` succeeded, `12` rate-limited
- live anonymous 12-search burst on this branch: `12/12` succeeded, `0` rate-limited
- focused NCBI regressions: `10/10`
- full `npm test`: `803/803`
- `npm run typecheck`
- `npm run build`
- `npm run architecture:check`
- root and website production audits: `0 vulnerabilities`
- website lint, typecheck, and build: `34` pages
- `git diff --check`
