### PR TITLE
Allow slow locked runtime restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-23 01:49 EDT — windows-runtime-timeout-0.3.36
+
+- Reproduced: Published-package E2E run `32620479741` passed Ubuntu Node `22/24/25`, macOS Node `24`, Windows Node `24`, and all three native installers, but Windows Node `25` terminated the exact-lock runtime `npm ci` at Feynman's fixed five-minute child-process timeout. The process then exited before `feynman --version`; the candidate's earlier Windows Node `25` run had completed the same path under the limit.
+- Fixed: Exact package-lock runtime restoration now has a bounded fifteen-minute budget. Lock ownership, exact lock identity, package-graph validation, mandatory pre-publication patches, and transactional publication remain unchanged and fail closed.
+- Verified locally: The focused fallback test passes `6/6`; the full suite passes `902/902`; typecheck, build, architecture, website lint/typecheck/build (`34` pages), root/site production audits, and `git diff --check` pass.
+- State: `unverified` until clean package and Windows proof, Daytona, successor PR CI, merge, publication, and post-release E2E pass. Next: qualify and release `0.3.36`.
+
 ### 2026-08-22 23:00 EDT — runtime-extraction-integrity-0.3.35-windows-alias
 
 - Reproduced: PR `#247` run `32613452545` passed source and website validation but the Windows native build failed while restoring the authenticated runtime. Git for Windows tar recreated the portable `@mariozechner/pi-coding-agent` directory alias as a link that `lstat` could verify but Node could not traverse to `package.json` or `dist/cli/args.js`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,17 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.36 - 2026-08-23
+
+### Research runtime
+
+- Cross-platform runtime repair now allows up to fifteen minutes for the exact locked npm restore. This keeps slow Windows and Node 25 clean installs from terminating a valid research-runtime rebuild at the previous five-minute process limit.
+
+### Validation
+
+- Reproduced the published `0.3.35` failure on Windows with Node 25 after npm exhausted the five-minute child-process budget, while the same package passed the other five Node/OS consumers and all three native installers.
+- Added an exact timeout regression and retained fail-closed lock, package-graph, and post-install verification.
+
 ## v0.3.35 - 2026-08-22
 
 ### Research runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.35",
+      "version": "0.3.36",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/scripts/lib/runtime-workspace-install.d.mts
+++ b/scripts/lib/runtime-workspace-install.d.mts
@@ -1,3 +1,5 @@
+export declare const RUNTIME_WORKSPACE_PACKAGE_INSTALL_TIMEOUT_MS: number;
+
 export declare function buildSourceRuntimeArchive(
 	appRoot: string,
 	options?: {

--- a/scripts/lib/runtime-workspace-install.mjs
+++ b/scripts/lib/runtime-workspace-install.mjs
@@ -16,6 +16,8 @@ const FILTERED_INSTALL_OUTPUT_PATTERNS = [
 	/^run `npm fund` for details$/i,
 ];
 
+export const RUNTIME_WORKSPACE_PACKAGE_INSTALL_TIMEOUT_MS = 15 * 60_000;
+
 function getPathWithCurrentNode(pathValue = process.env.PATH ?? "") {
 	const nodeDir = dirname(process.execPath);
 	const parts = pathValue.split(delimiter).filter(Boolean);
@@ -170,7 +172,7 @@ export function installRuntimeWorkspaceFromPackageLock(
 			cwd: workspaceDir,
 			shell: invocation.shell,
 			stdio: ["ignore", "pipe", "pipe"],
-			timeout: 300000,
+			timeout: RUNTIME_WORKSPACE_PACKAGE_INSTALL_TIMEOUT_MS,
 			env: {
 				...process.env,
 				PATH: getPathWithCurrentNode(),

--- a/tests/runtime-workspace-install.test.ts
+++ b/tests/runtime-workspace-install.test.ts
@@ -16,6 +16,7 @@ import {
 import {
 	buildSourceRuntimeArchive,
 	installRuntimeWorkspaceFromPackageLock,
+	RUNTIME_WORKSPACE_PACKAGE_INSTALL_TIMEOUT_MS,
 } from "../scripts/lib/runtime-workspace-install.mjs";
 
 test("source checkout builds the exact authenticated runtime archive", () => {
@@ -218,6 +219,7 @@ test("installed package cannot rebuild missing or damaged runtime archives", () 
 });
 
 test("package-manager fallback uses npm ci and rejects lock mutation", () => {
+	assert.equal(RUNTIME_WORKSPACE_PACKAGE_INSTALL_TIMEOUT_MS, 15 * 60_000);
 	const root = mkdtempSync(join(tmpdir(), "feynman-runtime-exact-lock-"));
 	const lockPath = join(root, "package-lock.json");
 	const lockSource =
@@ -244,6 +246,10 @@ test("package-manager fallback uses npm ci and rejects lock mutation", () => {
 					assert.equal(options.env.NPM_CONFIG_LOCATION, "project");
 					assert.equal(options.env.npm_config_dry_run, "false");
 					assert.equal(options.env.NPM_CONFIG_DRY_RUN, "false");
+					assert.equal(
+						options.timeout,
+						RUNTIME_WORKSPACE_PACKAGE_INSTALL_TIMEOUT_MS,
+					);
 					mkdirSync(join(root, "node_modules"));
 					return {
 						status: 0,

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,17 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.36 - 2026-08-23
+
+### Research runtime
+
+- Cross-platform runtime repair now allows up to fifteen minutes for the exact locked npm restore. This keeps slow Windows and Node 25 clean installs from terminating a valid research-runtime rebuild at the previous five-minute process limit.
+
+### Validation
+
+- Reproduced the published `0.3.35` failure on Windows with Node 25 after npm exhausted the five-minute child-process budget, while the same package passed the other five Node/OS consumers and all three native installers.
+- Added an exact timeout regression and retained fail-closed lock, package-graph, and post-install verification.
+
 ## v0.3.35 - 2026-08-22
 
 ### Research runtime


### PR DESCRIPTION
## Research job

Keep installed Feynman research runtimes recoverable on slow Windows and Node 25 clean installs without weakening exact-lock or transactional verification.

## Reproduction

Published-package E2E run `32620479741` passed the other five Node/OS consumers and all three native installers, but Windows Node 25 exhausted Feynman's fixed five-minute child-process timeout during exact-lock runtime `npm ci`. The runtime then failed closed before `feynman --version`. A later rerun completed below the old limit, confirming the failure is timing-sensitive rather than invalid package state.

## Fix

- allow the exact package-lock runtime restore up to fifteen minutes
- retain lock ownership, exact lock hashing, package-graph validation, mandatory patching, and transactional publication
- add an exact timeout regression
- publish as `0.3.36` with matching root and website release notes

## Verification

- exact head: `93cf4f293da52c58f6f5024408168ae56d33fb48`
- focused fallback tests: `6/6`
- isolated full `npm test`: `902/902`
- typecheck, build, architecture, and `git diff --check`: green
- website lint/typecheck/build: green (`34` pages)
- root, website, generated-runtime, installed-consumer, and extracted-runtime production audits: zero vulnerabilities
- deterministic local dry/real package: `116,430,558` bytes, `304,133,863` unpacked bytes, `29,170` files, SHA-256 `5392a9980596b58be6b680175df76bfff47dc39f7461762fbe26f45532d5ee24`
- same-Node 22 local/global consumers: version/help, package and search status, stale-Pi repair, package/runtime verification, extension/tools/TypeBox, document parse/search/screenshot all green
- clean Daytona Node 25: full `902/902`, source/site/audit/build ladder, deterministic package (`118,121,925` bytes; SHA-256 `def8c7c99a570b9de6abaf1422dcfa4cc88f5591010b34cb2b79e15538a5bbe1`), local/global consumers and installed runtime/docparser all green; sandbox deleted
- PR run `32621882417` is fully green: release candidate, all six Linux/macOS/Windows Node consumers (including Windows Node 25 in `34m34s`), and the Windows PowerShell 5.1/Core native installer (`46m34s`)
- CodeQL and Vercel preview are green

