### PR TITLE
Use IGV supported mapping origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-23 07:24 EDT — igv-mapping-origin-0.3.37
+
+- Objective: Refresh the complete post-`0.3.36` maintainer intake and remove one supported research-viewer reliability regression without adding unrelated dependency churn.
+- Intake: Open issues, pull requests, active workflows, and security-alert queues are empty. Recent `dubbypanda`, `TheTechOddBug`, `birhantprkc`, and newly created `Shergill08` forks are identical to `main`; the older `randomm` and `fuzzywigg` deltas remain fork-specific or superseded. Pi `0.84.2`, pi-web-access `0.24.2`, pi-docparser `4.0.0`, and LiteParse `2.13.1` remain current. The broad pi-subagents `0.55.0` workflow/fleet/control-plane migration, coordinated TypeBox, routine UI/tooling, npyjs, and patristic drift have no narrow unmet research-loop fix.
+- Reproduced: Feynman's embedded genome preview used IGV `3.8.4`, whose published browser bundle unconditionally points legacy URL-map loading at `raw.githubusercontent.com`. Upstream issue `#2087` confirms restrictive content-security policies can block that origin; IGV `3.8.5` moves the exact mapping request to `https://igv.org/data/url_mappings.tsv`.
+- Changed: Updated IGV to `3.8.5`, added an installed-bundle regression for the supported origin and absence of the old raw-GitHub mapping path, bumped Feynman to `0.3.37`, and updated root and website release notes.
+- Verification: Focused genome-parser, viewer-shell, and installed-IGV tests pass (`5/5`); the full suite passes (`903/903`); typecheck, build, architecture, website lint/typecheck/build (`34` pages), root/site/runtime/consumer audits, exact npm-artifact comparison, freshness review, and `git diff --check` pass. Dry and real packs match at `116,445,627` bytes and `29,176` files with SHA-256 `e09e7352946dd2c80fff7e1d4382a6381d424ec2106f46454e4bed8c2a6a83df`; clean local/global consumers pass package, runtime, extension/tool, TypeBox, document, and stale-upgrade checks. A headless Chrome run of the actual built workbench rendered a VCF in IGV `3.8.5`, received the mapping catalog from `igv.org` with HTTP `200`, made no request to the old mapping origin, and emitted no load failure, exception, or error log. State: `unverified` for exact-commit Daytona, CI, merge, publication, and post-release gates. Next: commit the candidate, prove the exact SHA in Daytona and CI, then merge and verify `0.3.37`.
+
 ### 2026-08-23 04:33 EDT — windows-runtime-timeout-0.3.36-release
 
 - Persistence: PR `#248` merged exact candidate `93cf4f293da52c58f6f5024408168ae56d33fb48` as `aaf678eb561a27dceb2ae68bc52e24a011366fac` after PR run `32621882417`, CodeQL, and Vercel passed the release candidate, all six package consumers, and the Windows PowerShell 5.1/Core native installer.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,16 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.37 - 2026-08-23
+
+### Research visualization
+
+- Updated IGV to `3.8.5`. Embedded VCF, BED, and GFF genome previews now load IGV's legacy URL-mapping catalog from `igv.org` instead of raw GitHub, avoiding unnecessary blocked-origin warnings under restrictive content-security policies.
+
+### Validation
+
+- Matched the installed package to the published `3.8.5` npm artifact and upstream commit `1ff36cd`, with an executable regression for the supported mapping origin.
+
 ## v0.3.36 - 2026-08-23
 
 ### Research runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.36",
+      "version": "0.3.37",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",
@@ -39,7 +39,7 @@
         "brace-expansion": "5.0.9",
         "d3": "^7.9.0",
         "fast-xml-parser": "5.11.0",
-        "igv": "^3.8.4",
+        "igv": "^3.8.5",
         "jszip": "^3.10.1",
         "npyjs": "^1.1.0",
         "patristic": "^0.5.7",
@@ -9172,9 +9172,9 @@
       }
     },
     "node_modules/igv": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/igv/-/igv-3.8.4.tgz",
-      "integrity": "sha512-XtZzlYxtGMMEaOlpPAcZIdGCIJ1n9RrPjmQgze6KNWQnppjmdRfPUmB11JJrX4FmtUf0GavALtXzhyJoWV5x3Q==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/igv/-/igv-3.8.5.tgz",
+      "integrity": "sha512-Tdt0+z0DlQULSPByZG4wm3CeF4VzI+WehEKUyPTsT8W+EhRVV8VVlIZA5U+OXl9mVRMOL444qvN7w4IZJaW9Xw==",
       "license": "MIT"
     },
     "node_modules/immediate": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",
@@ -121,7 +121,7 @@
     "brace-expansion": "5.0.9",
     "d3": "^7.9.0",
     "fast-xml-parser": "5.11.0",
-    "igv": "^3.8.4",
+    "igv": "^3.8.5",
     "jszip": "^3.10.1",
     "npyjs": "^1.1.0",
     "patristic": "^0.5.7",

--- a/tests/genome-viewer.test.ts
+++ b/tests/genome-viewer.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+test("bundled IGV loads legacy URL mappings from the supported IGV origin", () => {
+	const packageRoot = join(process.cwd(), "node_modules", "igv");
+	const packageJson = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as {
+		version?: string;
+	};
+	assert.equal(packageJson.version, "3.8.5");
+
+	const bundle = readFileSync(join(packageRoot, "dist", "igv.esm.js"), "utf8");
+	assert.match(bundle, /https:\/\/igv\.org\/data\/url_mappings\.tsv/);
+	assert.doesNotMatch(
+		bundle,
+		/https:\/\/raw\.githubusercontent\.com\/igvteam\/igv-data\/refs\/heads\/main\/data\/url_mappings\.tsv/,
+	);
+});

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,16 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.37 - 2026-08-23
+
+### Research visualization
+
+- Updated IGV to `3.8.5`. Embedded VCF, BED, and GFF genome previews now load IGV's legacy URL-mapping catalog from `igv.org` instead of raw GitHub, avoiding unnecessary blocked-origin warnings under restrictive content-security policies.
+
+### Validation
+
+- Matched the installed package to the published `3.8.5` npm artifact and upstream commit `1ff36cd`, with an executable regression for the supported mapping origin.
+
 ## v0.3.36 - 2026-08-23
 
 ### Research runtime


### PR DESCRIPTION
## Core research job

This improves reliable genome-evidence visualization inside the existing artifact inspector. It keeps the change on the smallest existing surface: the bundled IGV dependency and a package-level regression.

## What changed

- update IGV from `3.8.4` to `3.8.5`
- require the supported `https://igv.org/data/url_mappings.tsv` catalog in the installed browser bundle
- reject the former raw-GitHub mapping URL in regression coverage
- bump Feynman to `0.3.37`
- update root and public release notes

## Primary evidence

- Feynman's viewer initializes IGV with `genome: "hg38"`, which triggers the legacy URL-mapping catalog path.
- `igvteam/igv.js#2087` records restrictive-CSP failures for the raw-GitHub catalog origin.
- The official IGV `3.8.5` npm tarball and upstream release commit `1ff36cd` move that catalog to `igv.org`.
- A built-workbench Chrome run rendered a VCF using IGV `3.8.5`; the `igv.org` mapping request returned HTTP 200, no old-origin request occurred, and there were no loading failures or error logs.

## Validation before push

- focused genome/viewer tests: `5/5`
- full test suite: `903/903`
- root typecheck, build, architecture check
- website lint, typecheck, build (`34` pages)
- root, website, generated-runtime, clean-consumer, and extracted-runtime production audits: zero vulnerabilities
- dry/real package and clean local/global installed-consumer runtime, extension/tool, TypeBox, and document checks
- exact official IGV tarball identity and installed-bundle comparison
- two read-only adversarial reviews: no release blocker

Exact candidate: `796bde9266c11346b1daba6d6292c0f9ce1723ee`. Clean Daytona and the full PR package/OS matrix are required before merge.
