### PR TITLE
Release 0.3.40: clear image-only queue state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-24 15:38 EDT — pi-image-queue-0.3.40
+
+- Objective: Clear Pi's delivered image-only steering and follow-up records so research sessions that add screenshots or paper figures do not retain false pending-input state.
+- Reproduced: Bundled patched Pi `0.84.2` delivered the image and emptied its agent queue but left `pendingMessageCount` at `1`, with no clearing `queue_update`. Upstream issue `#8581` and proposed commit `b67b3db` identify the same truthiness guard.
+- Candidate: The existing version-gated Pi runtime correctness patch now matches empty text when a queued user message contains only images, verifies that the stale truthiness gate is absent, and exercises both steering and follow-up delivery. Focused tests pass `9/9`; the full suite passes `912/912`; root typecheck, build, architecture, and diff checks pass; website lint, typecheck, build (`34` pages), and both production audits pass.
+- State: `verified` for the source candidate and `unverified` for the exact committed package/runtime ladder, clean-machine proof, pull-request CI, merge, publication, and live release identity. Next: complete the release ladder and publish `0.3.40`.
+
 ### 2026-08-24 13:04 EDT — pi-compaction-integrity-0.3.39-release
 
 - Persistence: PR `#251` merged exact tested head `c86733f1b731eacd5c616711edac75f12ab260b7` as `cf00120843d3cec4d788170d99e296c9e83ed528`; the owning branch was deleted locally and remotely. The repository does not define `codex` or `codex-automation` labels.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,16 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.40 - 2026-08-24
+
+### Research continuity
+
+- Image-only steering and follow-up messages are now removed from Pi's pending queue state when they are delivered. Research sessions that add screenshots, paper figures, or other image context no longer remain falsely marked as waiting on input after the model receives the image.
+
+### Validation
+
+- Reproduced the defect on the bundled Pi `0.84.2`: the agent queue was empty after image delivery while `pendingMessageCount` remained `1` and no clearing `queue_update` event was emitted. Ported the focused fix from commit `b67b3db` across source, bundled, restored, installed, and package-artifact copies, with executable steering and follow-up regressions plus fail-closed patch verification.
+
 ## v0.3.39 - 2026-08-24
 
 ### Research continuity

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.39",
+      "version": "0.3.40",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/scripts/lib/pi-runtime-correctness-patch.d.mts
+++ b/scripts/lib/pi-runtime-correctness-patch.d.mts
@@ -9,8 +9,16 @@ export declare const PI_RUNTIME_CORRECTNESS_PATCH_MARKERS: Readonly<{
 	transformMessages: string;
 	githubCopilotDeviceCode: string;
 	githubCopilotOAuth: string;
+	imageQueue: string;
 }>;
 export declare const PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS: Readonly<{
+	agentSession: readonly string[];
+	sessionManager: readonly string[];
+	transformMessages: readonly string[];
+	githubCopilotDeviceCode: readonly string[];
+	githubCopilotOAuth: readonly string[];
+}>;
+export declare const PI_RUNTIME_CORRECTNESS_FORBIDDEN_FRAGMENTS: Readonly<{
 	agentSession: readonly string[];
 	sessionManager: readonly string[];
 	transformMessages: readonly string[];

--- a/scripts/lib/pi-runtime-correctness-patch.mjs
+++ b/scripts/lib/pi-runtime-correctness-patch.mjs
@@ -2,10 +2,12 @@
  * Temporary Pi 0.84.2 correctness patches for:
  * - https://github.com/earendil-works/pi/issues/7053
  * - https://github.com/earendil-works/pi/issues/8121
+ * - https://github.com/earendil-works/pi/issues/8581
  *
  * Removal condition: delete this patch once a supported released Pi version
  * eagerly persists finalized parallel tool results while restoring them in
- * tool-call order and includes upstream commits d5278ea and 086c32e.
+ * tool-call order, includes upstream commits d5278ea and 086c32e, and clears
+ * delivered image-only queue entries as in commit b67b3db.
  */
 export const PI_RUNTIME_CORRECTNESS_PATCH_TARGETS = Object.freeze({
 	codingAgent: Object.freeze([
@@ -25,10 +27,14 @@ export const PI_RUNTIME_CORRECTNESS_PATCH_MARKERS = Object.freeze({
 	transformMessages: "Feynman Pi 0.84.2 correctness patch: order eager tool results",
 	githubCopilotDeviceCode: "Feynman Pi 0.84.2 correctness patch: export abortableSleep for upstream #8121",
 	githubCopilotOAuth: "Feynman Pi 0.84.2 correctness patch: upstream #8121",
+	imageQueue: "Feynman Pi 0.84.2 correctness patch: image-only queue delivery #8581",
 });
 export const PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS = Object.freeze({
 	agentSession: Object.freeze([
 		PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.agentSession,
+		PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.imageQueue,
+		"const steeringIndex = this._steeringMessages.indexOf(messageText);",
+		"const followUpIndex = this._followUpMessages.indexOf(messageText);",
 		'const feynmanToolResultIdBeforeExtensions = event.type === "message_end" && event.message.role === "toolResult"',
 		"const entryId = this.sessionManager.appendMessage(toolResult);",
 		"this._feynmanEagerlyPersistedToolResults.set(event.toolCallId, {",
@@ -80,9 +86,20 @@ export const PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS = Object.freeze({
 		"await enableGitHubCopilotModel(token, model.id, enterpriseDomain, signal);",
 	]),
 });
+export const PI_RUNTIME_CORRECTNESS_FORBIDDEN_FRAGMENTS = Object.freeze({
+	agentSession: Object.freeze([
+		`            if (messageText) {
+                // Check steering queue first`,
+	]),
+	sessionManager: Object.freeze([]),
+	transformMessages: Object.freeze([]),
+	githubCopilotDeviceCode: Object.freeze([]),
+	githubCopilotOAuth: Object.freeze([]),
+});
 
 const PI_RUNTIME_CORRECTNESS_ORDERED_FRAGMENTS = Object.freeze({
 	agentSession: Object.freeze([
+		PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.imageQueue,
 		"const entryId = this.sessionManager.appendMessage(toolResult);",
 		"await this._emitExtensionEvent(event);",
 		"event.message.toolCallId = feynmanToolResultIdBeforeExtensions;",
@@ -128,13 +145,31 @@ export function assertPiRuntimeCorrectnessVersion(version, surface) {
 
 export function assertPiRuntimeCorrectnessPatchSource(source, target, surface = target) {
 	const required = PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS[target];
+	const forbidden = PI_RUNTIME_CORRECTNESS_FORBIDDEN_FRAGMENTS[target];
 	const ordered = PI_RUNTIME_CORRECTNESS_ORDERED_FRAGMENTS[target];
-	if (!required || !ordered) {
+	if (!required || !forbidden || !ordered) {
 		throw new Error(`Unknown Pi runtime correctness target: ${target}`);
 	}
 	for (const fragment of required) {
 		if (!source.includes(fragment)) {
 			throw new Error(`Incomplete Pi runtime correctness patch ${surface}: missing ${fragment}`);
+		}
+	}
+	for (const fragment of forbidden) {
+		if (source.includes(fragment)) {
+			throw new Error(`Incomplete Pi runtime correctness patch ${surface}: retained ${fragment}`);
+		}
+	}
+	if (target === "agentSession") {
+		if (/\bif\s*\([^{}\n]*\bmessageText\b[^{}\n]*\)\s*\{/.test(source)) {
+			throw new Error(
+				`Incomplete Pi runtime correctness patch ${surface}: retained messageText truthiness guard`,
+			);
+		}
+		if (!source.includes(PATCHED_IMAGE_QUEUE_EVENT_HANDLER)) {
+			throw new Error(
+				`Incomplete Pi runtime correctness patch ${surface}: missing exact image-only queue event handler`,
+			);
 		}
 	}
 	let previousIndex = -1;
@@ -155,6 +190,60 @@ function replaceRequired(source, original, replacement, label) {
 		);
 	}
 	return source.replace(original, replacement);
+}
+
+const ORIGINAL_IMAGE_QUEUE_DELIVERY = `            const messageText = contentText(event.message.content, "");
+            if (messageText) {
+                // Check steering queue first
+                const steeringIndex = this._steeringMessages.indexOf(messageText);
+                if (steeringIndex !== -1) {
+                    this._steeringMessages.splice(steeringIndex, 1);
+                    this._emitQueueUpdate();
+                }
+                else {
+                    // Check follow-up queue
+                    const followUpIndex = this._followUpMessages.indexOf(messageText);
+                    if (followUpIndex !== -1) {
+                        this._followUpMessages.splice(followUpIndex, 1);
+                        this._emitQueueUpdate();
+                    }
+                }
+            }`;
+
+const PATCHED_IMAGE_QUEUE_DELIVERY = `            const messageText = contentText(event.message.content, "");
+            // ${PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.imageQueue}
+            // Empty text is valid when a queued user message contains only images.
+            // Match it just like textual steering and follow-up messages.
+            const steeringIndex = this._steeringMessages.indexOf(messageText);
+            if (steeringIndex !== -1) {
+                this._steeringMessages.splice(steeringIndex, 1);
+                this._emitQueueUpdate();
+            }
+            else {
+                // Check follow-up queue
+                const followUpIndex = this._followUpMessages.indexOf(messageText);
+                if (followUpIndex !== -1) {
+                    this._followUpMessages.splice(followUpIndex, 1);
+                    this._emitQueueUpdate();
+                }
+            }`;
+
+const PATCHED_IMAGE_QUEUE_EVENT_HANDLER = `        if (event.type === "message_start" && event.message.role === "user") {
+            this._overflowRecoveryAttempted = false;
+${PATCHED_IMAGE_QUEUE_DELIVERY}
+        }
+        const feynmanToolResultIdBeforeExtensions =`;
+
+function patchPiImageQueueDeliverySource(source) {
+	if (source.includes(PI_RUNTIME_CORRECTNESS_PATCH_MARKERS.imageQueue)) {
+		return source;
+	}
+	return replaceRequired(
+		source,
+		ORIGINAL_IMAGE_QUEUE_DELIVERY,
+		PATCHED_IMAGE_QUEUE_DELIVERY,
+		"agent-session image-only queue delivery",
+	);
 }
 
 const AGENT_SESSION_HELPERS = `
@@ -269,6 +358,7 @@ const PATCHED_MESSAGE_PERSISTENCE = `            else if (event.message.role ===
             }`;
 
 export function patchPiAgentSessionSource(source) {
+	source = patchPiImageQueueDeliverySource(source);
 	if (source.includes(AGENT_SESSION_MARKER)) {
 		try {
 			assertPiRuntimeCorrectnessPatchSource(source, "agentSession");

--- a/tests/pi-image-queue.test.ts
+++ b/tests/pi-image-queue.test.ts
@@ -1,0 +1,158 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Context } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+
+import { patchPiRuntimeNodeModules } from "../src/pi/runtime-patches.js";
+
+const appRoot = process.cwd();
+patchPiRuntimeNodeModules(appRoot);
+
+function createResourceLoader(runtime: unknown) {
+	return {
+		getExtensions: () => ({
+			extensions: [],
+			errors: [],
+			runtime,
+		}),
+		getSkills: () => ({ skills: [], diagnostics: [] }),
+		getPrompts: () => ({ prompts: [], diagnostics: [] }),
+		getThemes: () => ({ themes: [], diagnostics: [] }),
+		getAgentsFiles: () => ({ agentsFiles: [] }),
+		getSystemPrompt: () => undefined,
+		getAppendSystemPrompt: () => [],
+		extendResources: () => {},
+		reload: async () => {},
+	};
+}
+
+test("real image-only steering and follow-up delivery clears colliding empty queue keys", async (t) => {
+	const [{ Agent }, codingAgent, piAi] = await Promise.all([
+		import("@earendil-works/pi-agent-core"),
+		import("@earendil-works/pi-coding-agent"),
+		import("@earendil-works/pi-ai/compat"),
+	]);
+	const { AgentSession, SessionManager, SettingsManager, convertToLlm } = codingAgent;
+	const { fauxAssistantMessage, fauxToolCall, registerFauxProvider, streamSimple } = piAi;
+	const faux = registerFauxProvider({
+		models: [{ id: "faux-image-queue", input: ["text", "image"] }],
+	});
+	let disposeSession: (() => void) | undefined;
+	t.after(() => {
+		disposeSession?.();
+		faux.unregister();
+	});
+
+	let markToolStarted: (() => void) | undefined;
+	const toolStarted = new Promise<void>((resolveStarted) => {
+		markToolStarted = resolveStarted;
+	});
+	let releaseTool: (() => void) | undefined;
+	const toolGate = new Promise<void>((resolveTool) => {
+		releaseTool = resolveTool;
+	});
+	const waitTool = {
+		name: "wait",
+		label: "wait",
+		description: "Hold the turn while image-only messages are queued",
+		parameters: Type.Object({}),
+		execute: async () => {
+			markToolStarted?.();
+			await toolGate;
+			return {
+				content: [{ type: "text" as const, text: "released" }],
+				details: {},
+			};
+		},
+	};
+	const model = faux.getModel();
+	const modelRuntime = {
+		hasConfiguredAuth: () => true,
+		checkAuth: async () => ({ auth: { apiKey: "faux-key" } }),
+		getAuth: async () => ({ auth: { apiKey: "faux-key" } }),
+		isUsingOAuth: () => false,
+	};
+	const agent = new Agent({
+		getApiKey: () => "faux-key",
+		streamFn: streamSimple,
+		initialState: {
+			model,
+			systemPrompt: "You are a test assistant.",
+			tools: [],
+		},
+		convertToLlm,
+	});
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(appRoot),
+		settingsManager: SettingsManager.inMemory({ compaction: { enabled: false } }),
+		cwd: appRoot,
+		modelRuntime: modelRuntime as never,
+		resourceLoader: createResourceLoader(codingAgent.createExtensionRuntime()) as never,
+		baseToolsOverride: { wait: waitTool },
+	});
+	disposeSession = () => session.dispose();
+
+	const receivedImageData: string[] = [];
+	const recordLatestImage = (context: Context) => {
+		const user = [...context.messages].reverse().find((message) => message.role === "user");
+		const image = user?.role === "user" && Array.isArray(user.content)
+			? user.content.find((part) => part.type === "image")
+			: undefined;
+		assert.equal(image?.type, "image");
+		receivedImageData.push(image?.type === "image" ? image.data : "");
+	};
+	faux.setResponses([
+		fauxAssistantMessage(fauxToolCall("wait", {}, { id: "wait-call" }), {
+			stopReason: "toolUse",
+		}),
+		(context) => {
+			recordLatestImage(context);
+			return fauxAssistantMessage("steering image received");
+		},
+		(context) => {
+			recordLatestImage(context);
+			return fauxAssistantMessage("follow-up image received");
+		},
+	]);
+
+	const updates: Array<{ steering: string[]; followUp: string[] }> = [];
+	session.subscribe((event) => {
+		if (event.type === "queue_update") {
+			updates.push({
+				steering: [...event.steering],
+				followUp: [...event.followUp],
+			});
+		}
+	});
+	const followUpImage = {
+		type: "image" as const,
+		mimeType: "image/png",
+		data: "Zm9sbG93LXVw",
+	};
+	const steeringImage = {
+		type: "image" as const,
+		mimeType: "image/png",
+		data: "c3RlZXI=",
+	};
+
+	const prompt = session.prompt("wait for queued images");
+	await toolStarted;
+	await session.followUp("", [followUpImage]);
+	await session.steer("", [steeringImage]);
+	assert.equal(session.pendingMessageCount, 2);
+	assert.deepEqual(updates.at(-1), { steering: [""], followUp: [""] });
+	releaseTool?.();
+	await prompt;
+
+	assert.deepEqual(receivedImageData, [steeringImage.data, followUpImage.data]);
+	assert.equal(session.agent.hasQueuedMessages(), false);
+	assert.equal(session.pendingMessageCount, 0);
+	assert.deepEqual(updates, [
+		{ steering: [], followUp: [""] },
+		{ steering: [""], followUp: [""] },
+		{ steering: [], followUp: [""] },
+		{ steering: [], followUp: [] },
+	]);
+});

--- a/tests/pi-runtime-correctness-patch.test.ts
+++ b/tests/pi-runtime-correctness-patch.test.ts
@@ -11,6 +11,7 @@ import { Type } from "typebox";
 import {
 	assertPiRuntimeCorrectnessPatchSource,
 	assertPiRuntimeCorrectnessVersion,
+	PI_RUNTIME_CORRECTNESS_FORBIDDEN_FRAGMENTS,
 	PI_RUNTIME_CORRECTNESS_REQUIRED_FRAGMENTS,
 	PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION,
 	patchPiAgentSessionSource,
@@ -149,6 +150,7 @@ test("Pi 0.84.2 correctness patch is applied, idempotent, and documents its remo
 	);
 
 	assert.match(agentSessionSource, /issue #7053/);
+	assert.match(agentSessionSource, /image-only queue delivery #8581/);
 	assert.match(agentSessionSource, /Cannot submit a prompt while compaction is in progress/);
 	assert.match(agentSessionSource, /_feynmanEagerlyPersistedToolResults/);
 	assert.match(agentSessionSource, /feynmanToolResultIdBeforeExtensions/);
@@ -176,6 +178,7 @@ test("Pi 0.84.2 correctness patch is applied, idempotent, and documents its remo
 	}
 	assert.match(patchSource, /Removal condition: delete this patch once a supported released Pi version/);
 	assert.match(patchSource, /upstream commits d5278ea and 086c32e/);
+	assert.match(patchSource, /delivered image-only queue entries as in commit b67b3db/);
 
 	assert.equal(patchPiAgentSessionSource(agentSessionSource), agentSessionSource);
 	assert.equal(patchPiSessionManagerSource(sessionManagerSource), sessionManagerSource);
@@ -211,6 +214,12 @@ test("Pi 0.84.2 correctness patch is applied, idempotent, and documents its remo
 				/Incomplete Pi runtime correctness patch/,
 			);
 		}
+		for (const fragment of PI_RUNTIME_CORRECTNESS_FORBIDDEN_FRAGMENTS[target]) {
+			assert.throws(
+				() => assertPiRuntimeCorrectnessPatchSource(`${source}\n${fragment}`, target),
+				/Incomplete Pi runtime correctness patch/,
+			);
+		}
 	}
 	const appendFragment = "const entryId = this.sessionManager.appendMessage(toolResult);";
 	const extensionFragment = "await this._emitExtensionEvent(event);";
@@ -222,9 +231,27 @@ test("Pi 0.84.2 correctness patch is applied, idempotent, and documents its remo
 		() => assertPiRuntimeCorrectnessPatchSource(reorderedAgentSession, "agentSession"),
 		/out of order/,
 	);
+	const reformattedImageQueueGuard = agentSessionSource.replace(
+		"            // Empty text is valid when a queued user message contains only images.\n",
+		"            if (messageText) {\n            // Empty text is valid when a queued user message contains only images.\n",
+	);
+	assert.notEqual(reformattedImageQueueGuard, agentSessionSource);
+	assert.throws(
+		() => assertPiRuntimeCorrectnessPatchSource(reformattedImageQueueGuard, "agentSession"),
+		/retained messageText truthiness guard/,
+	);
+	const wrappedImageQueueGuard = agentSessionSource.replace(
+		'            const messageText = contentText(event.message.content, "");\n',
+		'            if ( messageText ) {\n            const messageText = contentText(event.message.content, "");\n',
+	);
+	assert.notEqual(wrappedImageQueueGuard, agentSessionSource);
+	assert.throws(
+		() => assertPiRuntimeCorrectnessPatchSource(wrappedImageQueueGuard, "agentSession"),
+		/retained messageText truthiness guard/,
+	);
 	assert.throws(
 		() => patchPiAgentSessionSource("export class AgentSession {}\n"),
-		/Unsupported Pi 0\.84\.2 agent-session import layout/,
+		/Unsupported Pi 0\.84\.2 agent-session image-only queue delivery layout/,
 	);
 	assert.throws(
 		() => patchPiGithubCopilotDeviceCodeSource("function sleep() {}\n"),

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,16 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.40 - 2026-08-24
+
+### Research continuity
+
+- Image-only steering and follow-up messages are now removed from Pi's pending queue state when they are delivered. Research sessions that add screenshots, paper figures, or other image context no longer remain falsely marked as waiting on input after the model receives the image.
+
+### Validation
+
+- Reproduced the defect on the bundled Pi `0.84.2`: the agent queue was empty after image delivery while `pendingMessageCount` remained `1` and no clearing `queue_update` event was emitted. Ported the focused fix from commit `b67b3db` across source, bundled, restored, installed, and package-artifact copies, with executable steering and follow-up regressions plus fail-closed patch verification.
+
 ## v0.3.39 - 2026-08-24
 
 ### Research continuity


### PR DESCRIPTION
## Research job

Preserve reliable screenshot, paper-figure, and other image-context turns in active research sessions.

## Fix

- reproduce Pi's image-only queue bug on the bundled patched `0.84.2` runtime
- clear the delivered queue record even when its text projection is empty
- fail closed if the stale `messageText` truthiness gate reappears
- cover colliding image-only steering and follow-up records through a real faux-provider agent loop
- release the fix as `0.3.40` with public release-note parity

This is a focused port of the root-cause change proposed in earendil-works/pi#8581 / `b67b3db`; the maintained patch remains exact-version gated until a compatible Pi release contains the fix and Feynman's other forward fixes.

## Source validation

- focused queue/runtime tests: 9/9
- full test suite: 912/912
- typecheck, build, architecture check, and `git diff --check`: passed
- website lint, typecheck, build: passed (34 pages)
- root and website production audits: 0 vulnerabilities
- adversarial review: no remaining release-blocking defect

Exact package, clean-consumer, Daytona, and CI receipts will be reconciled before merge.
