### PR TITLE
Fix legacy pi-subagents upgrade crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-25 19:32 EDT — pi-subagents-legacy-install-0.3.43
+
+- Objective: Repair issue `#255`, where a native-bundle `--version` check crashed while migrating the legacy `pi-subagents@0.37.2` management source left by an older Feynman installation.
+- Reproduced: The current patch threw `Cannot apply Feynman backport ... missing management list diagnostics` against the published `pi-subagents@0.37.2` source; the bundled `0.40.0` source remained green.
+- Changed: Added a legacy management-layout port for list and get diagnostics, with compact and multiline source anchors, while leaving unsupported layouts unchanged rather than throwing.
+- Verified: Focused `pi-subagents` coverage passed `32/32`; exact `0.37.2` and `0.40.0` source probes both patch and are idempotent. State: `unverified` for exact `0.3.43` package/native/Daytona/CI/release proof. Next: run the cumulative release ladder, then publish and close `#255`.
+
 ### 2026-08-25 16:25 EDT — pi-reasoning-integrity-0.3.42
 
 - Objective: Repair the released `0.3.41` OpenAI-compatible reasoning loss and provider-boundary leak, then make the exact-version Pi patch validators reject stale or semantically disabled runtime copies.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,16 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.43 - 2026-08-25
+
+### Installation reliability
+
+- Upgrading from an older Feynman installation no longer crashes while migrating a legacy `pi-subagents` package's agent diagnostics source. Fresh native-bundle installs and updates now tolerate the older management-source layout while preserving malformed-agent diagnostics.
+
+### Validation
+
+- Added an executable source regression for the `pi-subagents@0.37.2` management layout that previously raised `missing management list diagnostics` during `--version`.
+
 ## v0.3.42 - 2026-08-25
 
 ### Reasoning integrity

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.42",
+      "version": "0.3.43",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/scripts/lib/pi-subagents-agent-diagnostics-patch.mjs
+++ b/scripts/lib/pi-subagents-agent-diagnostics-patch.mjs
@@ -109,12 +109,135 @@ function patchExecutor(source) {
 	return patched;
 }
 
+function patchLegacyManagement(source) {
+	const legacyListAnchor = [
+		"\t\t...(diagnostics.length ? [",
+		"\t\t\t\"\",",
+		"\t\t\t\"Chain diagnostics:\",",
+		"\t\t\t...diagnostics.map((entry) => `- ${entry.filePath}: ${entry.error}`),",
+		"\t\t] : []),",
+	].join("\n");
+	const compactLegacyListAnchor =
+		"\t\t...(diagnostics.length ? [\"\", \"Chain diagnostics:\", ...diagnostics.map((entry) => `- ${entry.filePath}: ${entry.error}`)] : []),";
+	const legacyGetAnchor = [
+		"\t\tconst raw = params.agent.trim();",
+		"\t\tconst sanitized = sanitizeName(raw);",
+		"\t\tconst d = discoverAgentsAll(ctx.cwd);",
+		"\t\tconst matches = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package)",
+		"\t\t\t.filter((agent) => agent.name === raw || agent.name === sanitized);",
+		"\t\tif (!matches.length) {",
+		"\t\t\tconst msg = `Agent '${params.agent}' not found. Available: ${availableNames(ctx.cwd, \"agent\").join(\", \") || \"none\"}.`;",
+		"\t\t\tif (!hasBoth) return result(msg, true);",
+		"\t\t\tblocks.push(msg);",
+		"\t\t} else {",
+	].join("\n");
+	const listAnchor = source.includes(legacyListAnchor)
+		? legacyListAnchor
+		: source.includes(compactLegacyListAnchor)
+			? compactLegacyListAnchor
+			: undefined;
+
+	if (!listAnchor || !source.includes(legacyGetAnchor)) {
+		return source;
+	}
+
+	let patched = replaceRequired(
+		source,
+		[
+			"\ttype AgentConfig,",
+			"\ttype AgentScope,",
+		].join("\n"),
+		[
+			"\ttype AgentConfig,",
+			"\ttype AgentDiscoveryDiagnostic,",
+			"\ttype AgentScope,",
+		].join("\n"),
+		"legacy management diagnostic type import",
+	);
+	patched = replaceRequired(
+		patched,
+		[
+			"\tdiscoverAgentsAll,",
+			"\tbuildRuntimeName,",
+		].join("\n"),
+		[
+			"\tdiscoverAgentsAll,",
+			"\tfindBlockingAgentDiagnostic,",
+			"\tbuildRuntimeName,",
+		].join("\n"),
+		"legacy management diagnostic import",
+	);
+	patched = replaceRequired(
+		patched,
+		"function findChains(name: string, cwd: string, scope: AgentScope = \"both\"): ChainConfig[] {",
+		[
+			"function diagnosticsForScope(diagnostics: AgentDiscoveryDiagnostic[] | undefined, scope: AgentScope): AgentDiscoveryDiagnostic[] | undefined {",
+			"\tif (scope === \"both\") return diagnostics;",
+			"\tconst excludedSource = scope === \"user\" ? \"project\" : \"user\";",
+			"\treturn diagnostics?.filter((diagnostic) => diagnostic.source !== excludedSource);",
+			"}",
+			"",
+			"function findChains(name: string, cwd: string, scope: AgentScope = \"both\"): ChainConfig[] {",
+		].join("\n"),
+		"legacy management diagnostic scope",
+	);
+	patched = replaceRequired(
+		patched,
+		listAnchor,
+		[
+			listAnchor,
+			"\t\t...(diagnosticsForScope(d.agentDiagnostics, scope)?.length ? [",
+			"\t\t\t\"\",",
+			"\t\t\t\"Invalid agent definitions:\",",
+			"\t\t\t...diagnosticsForScope(d.agentDiagnostics, scope)!.map((diagnostic) => `- ${diagnostic.name ?? diagnostic.filePath} (${diagnostic.source}): ${diagnostic.error}`),",
+			"\t\t] : []),",
+		].join("\n"),
+		"legacy management list diagnostics",
+	);
+	patched = replaceRequired(
+		patched,
+		legacyGetAnchor,
+		[
+			"\t\tconst raw = params.agent.trim();",
+			"\t\tconst sanitized = sanitizeName(raw);",
+			"\t\tconst d = discoverAgentsAll(ctx.cwd);",
+			"\t\tconst matches = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package)",
+			"\t\t\t.filter((agent) => agent.name === raw || agent.name === sanitized);",
+			"\t\tconst diagnostics = diagnosticsForScope(d.agentDiagnostics, scope);",
+			"\t\tconst diagnostic = findBlockingAgentDiagnostic(raw, matches, diagnostics)",
+			"\t\t\t?? (sanitized !== raw ? findBlockingAgentDiagnostic(sanitized, matches, diagnostics) : undefined);",
+			"\t\tif (diagnostic) {",
+			"\t\t\tconst msg = `Agent '${params.agent}' has invalid configuration: ${diagnostic.error}`;",
+			"\t\t\tif (!hasBoth) return result(msg, true);",
+			"\t\t\tblocks.push(msg);",
+			"\t\t} else if (!matches.length) {",
+			"\t\t\tconst msg = `Agent '${params.agent}' not found. Available: ${availableNames(ctx.cwd, \"agent\").join(\", \") || \"none\"}.`;",
+			"\t\t\tif (!hasBoth) return result(msg, true);",
+			"\t\t\tblocks.push(msg);",
+			"\t\t} else {",
+		].join("\n"),
+		"legacy management get diagnostics",
+	);
+	return patched;
+}
+
 function patchManagement(source) {
 	if (source.includes("\"Invalid agent definitions:\"")) {
 		return source;
 	}
 	if (!source.includes("export function handleList(params: ManagementParams")) {
 		return source;
+	}
+	const currentListAnchor = [
+		"\t\t...(restrictedAgents.length ? [",
+		"\t\t\t\"\",",
+		"\t\t\t`Restricted agents (not executable in this session${restrictedSources?.length ? `; capability ceiling: ${restrictedSources.join(\", \")}` : \"\"}):`,",
+		"\t\t\t...restrictedAgents.map((a) => `- ${a.name} (${a.source}${a.aliases?.length ? `, aliases: ${a.aliases.join(\", \")}` : \"\"}): ${a.description}`),",
+		"\t\t] : []),",
+		"\t\t\"\",",
+	].join("\n");
+	if (!source.includes(currentListAnchor)) {
+		return patchLegacyManagement(source);
 	}
 	let patched = replaceRequired(
 		source,

--- a/tests/pi-subagents-patch.test.ts
+++ b/tests/pi-subagents-patch.test.ts
@@ -574,6 +574,88 @@ test("patchPiSubagentsSource leaves current getAgentDir agents.ts discovery path
 	assertUserDirLoadsHaveDeclaration(patched);
 });
 
+test("patchPiSubagentsSource upgrades legacy pi-subagents management diagnostics without crashing", () => {
+	const input = [
+		"import {",
+		"\ttype AgentConfig,",
+		"\ttype AgentScope,",
+		"\ttype AgentSource,",
+		"\ttype ChainConfig,",
+		"\tdiscoverAgentsAll,",
+		"\tbuildRuntimeName,",
+		'} from "./agents.ts";',
+		"function sanitizeName(name: string): string { return name; }",
+		"function findChains(name: string, cwd: string, scope: AgentScope = \"both\"): ChainConfig[] { return []; }",
+		"function mergeAgentsForScope(scope: AgentScope, user: AgentConfig[], project: AgentConfig[], builtin: AgentConfig[], pkg: AgentConfig[]): AgentConfig[] { return []; }",
+		"function availableNames(cwd: string, kind: \"agent\"): string[] { return []; }",
+		"function result(text: string, isError = false) { return { text, isError }; }",
+		"export function handleList(params: ManagementParams, ctx: ManagementContext) {",
+		"\tconst scope = normalizeListScope(params.agentScope) ?? \"both\";",
+		"\tconst d = discoverAgentsAll(ctx.cwd);",
+		"\tconst agents = [];",
+		"\tconst chains = [];",
+		"\tconst diagnostics = d.chainDiagnostics.filter((entry) => scope === \"both\" || entry.source === scope);",
+		"\tconst lines = [",
+		"\t\t\"Executable agents:\",",
+		"\t\t...(diagnostics.length ? [",
+		"\t\t\t\"\",",
+		"\t\t\t\"Chain diagnostics:\",",
+		"\t\t\t...diagnostics.map((entry) => `- ${entry.filePath}: ${entry.error}`),",
+		"\t\t] : []),",
+		"\t];",
+		"\treturn result(lines.join(\"\\n\"));",
+		"}",
+		"function findAgents(name: string, cwd: string, scope: AgentScope = \"both\"): AgentConfig[] { return []; }",
+		"function formatAgentDetail(agent: AgentConfig): string { return agent.name; }",
+		"function findChainDetails(name: string, cwd: string, scope: AgentScope): ChainConfig[] { return []; }",
+		"function formatChainDetail(chain: ChainConfig): string { return chain.name; }",
+		"function handleGet(params: ManagementParams, ctx: ManagementContext) {",
+		"\tconst scope = normalizeListScope(params.agentScope);",
+		"\tconst hasBoth = Boolean(params.agent && params.chainName);",
+		"\tconst blocks: string[] = [];",
+		"\tlet anyFound = false;",
+		"\tif (params.agent) {",
+		"\t\tconst raw = params.agent.trim();",
+		"\t\tconst sanitized = sanitizeName(raw);",
+		"\t\tconst d = discoverAgentsAll(ctx.cwd);",
+		"\t\tconst matches = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package)",
+		"\t\t\t.filter((agent) => agent.name === raw || agent.name === sanitized);",
+		"\t\tif (!matches.length) {",
+		"\t\t\tconst msg = `Agent '${params.agent}' not found. Available: ${availableNames(ctx.cwd, \"agent\").join(\", \") || \"none\"}.`;",
+		"\t\t\tif (!hasBoth) return result(msg, true);",
+		"\t\t\tblocks.push(msg);",
+		"\t\t} else {",
+		"\t\t\tanyFound = true;",
+		"\t\t\tblocks.push(...matches.map(formatAgentDetail));",
+		"\t\t}",
+		"\t}",
+		"}",
+	].join("\n");
+
+	const patched = patchPiSubagentsSource("src/agents/agent-management.ts", input);
+	assert.match(patched, /Invalid agent definitions:/);
+	assert.match(patched, /findBlockingAgentDiagnostic/);
+	assert.match(patched, /has invalid configuration:/);
+	assert.equal(patchPiSubagentsSource("src/agents/agent-management.ts", patched), patched);
+
+	const compactInput = input.replace(
+		[
+			"\t\t...(diagnostics.length ? [",
+			"\t\t\t\"\",",
+			"\t\t\t\"Chain diagnostics:\",",
+			"\t\t\t...diagnostics.map((entry) => `- ${entry.filePath}: ${entry.error}`),",
+			"\t\t] : []),",
+		].join("\n"),
+		"\t\t...(diagnostics.length ? [\"\", \"Chain diagnostics:\", ...diagnostics.map((entry) => `- ${entry.filePath}: ${entry.error}`)] : []),",
+	);
+	const compactPatched = patchPiSubagentsSource("src/agents/agent-management.ts", compactInput);
+	assert.match(compactPatched, /Invalid agent definitions:/);
+	assert.equal(
+		patchPiSubagentsSource("src/agents/agent-management.ts", compactPatched),
+		compactPatched,
+	);
+});
+
 test("patchPiSubagentsSource repairs current half-patched agents.ts userDir loads", () => {
 	const input = [
 		'import * as fs from "node:fs";',

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,16 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.43 - 2026-08-25
+
+### Installation reliability
+
+- Upgrading from an older Feynman installation no longer crashes while migrating a legacy `pi-subagents` package's agent diagnostics source. Fresh native-bundle installs and updates now tolerate the older management-source layout while preserving malformed-agent diagnostics.
+
+### Validation
+
+- Added an executable source regression for the `pi-subagents@0.37.2` management layout that previously raised `missing management list diagnostics` during `--version`.
+
 ## v0.3.42 - 2026-08-25
 
 ### Reasoning integrity


### PR DESCRIPTION
## Summary

Fixes #255. Native-bundle `--version` could crash while patching a legacy `pi-subagents@0.37.2` management source left by an older Feynman installation:

```
Cannot apply Feynman backport ... missing management list diagnostics
```

The patch now recognizes the legacy multiline and compact management layouts, ports list/get agent diagnostics, and remains idempotent. Unsupported management layouts are left unchanged instead of throwing during startup.

## Evidence

- Exact published `pi-subagents@0.37.2` source: current patch reproduced the exception; the candidate patches it and is idempotent.
- Exact published `pi-subagents@0.40.0` source: candidate remains idempotent.
- Focused `pi-subagents` tests: 32/32.
- Full `npm test`: 936/936.
- Root typecheck, build, architecture check, diff check, package audit, pack dry-run/real pack, website lint/typecheck/build, and a clean installed tarball consumer audit passed.
- Clean installed tarball consumer with a seeded legacy managed `pi-subagents@0.37.2` returned `0.3.43` on two launches and persisted the repaired marker.

Release metadata is prepared for `0.3.43`; native/Daytona and required GitHub release gates remain to run on the exact pushed head.
