### PR TITLE
Preserve research runtime integrity in 0.3.44

### DIFF
--- a/.feynman/runtime-package-lock.json
+++ b/.feynman/runtime-package-lock.json
@@ -2356,9 +2356,9 @@
       }
     },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
-      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.3.tgz",
+      "integrity": "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -2455,9 +2455,9 @@
       }
     },
     "node_modules/@llamaindex/liteparse": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.13.1.tgz",
-      "integrity": "sha512-EtMFEYFZIY+Gpj6nebvyiIkU9NTmLG5CXe2WpYy5S0pjCLfFgW0Tn9iN68ik3QIk64ELSdLJlgijSzCzfSpeoQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.14.0.tgz",
+      "integrity": "sha512-lIFBbTRs87Bpp45Lm986hUDEPndm85pT9l/BM1dtWhQs0zTLEkpHLrgbOxGG2rjBqDgJM5fdChT8LWUd4ZThWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"
@@ -2470,19 +2470,19 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@llamaindex/liteparse-darwin-arm64": "2.13.1",
-        "@llamaindex/liteparse-darwin-x64": "2.13.1",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.13.1",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.13.1",
-        "@llamaindex/liteparse-linux-x64-musl": "2.13.1",
-        "@llamaindex/liteparse-win32-arm64-msvc": "2.13.1",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.13.1"
+        "@llamaindex/liteparse-darwin-arm64": "2.14.0",
+        "@llamaindex/liteparse-darwin-x64": "2.14.0",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.14.0",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.14.0",
+        "@llamaindex/liteparse-linux-x64-musl": "2.14.0",
+        "@llamaindex/liteparse-win32-arm64-msvc": "2.14.0",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.14.0"
       }
     },
     "node_modules/@llamaindex/liteparse-darwin-arm64": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.13.1.tgz",
-      "integrity": "sha512-twznsLWeUD0QtSmZjjEQOZF/opFjJORbSILLNz41eM4PP0O2WT87ZAdUxLnPiA7JPZ6TdfoEc9lvAJfQPUHNig==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.14.0.tgz",
+      "integrity": "sha512-waYoHguqomVv43KEEqNf6nWSrpfMnNC8LXRtgN+a7F/WwICfNzrgA5Z8ayj2jhvvpYv7tsJ25M1vl8bb0i5UlA==",
       "cpu": [
         "arm64"
       ],
@@ -2493,9 +2493,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-darwin-x64": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.13.1.tgz",
-      "integrity": "sha512-Im0RwZCztuK+x+may8QRvtFhk1rfGtVMYHvKRHXh+NG+reWFKCTpUkOGrlrW5ik4lu3nzd4Svjbg015zw8zCRQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.14.0.tgz",
+      "integrity": "sha512-akTk/e6eEHgeP14f+8QiqueiEjiHTutX03XxRizXNn2aoTtQCEfElN4/p0rwTSFq35E76N7/z3ZVP5l1h4G4pw==",
       "cpu": [
         "x64"
       ],
@@ -2506,9 +2506,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-arm64-gnu": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.13.1.tgz",
-      "integrity": "sha512-L0n95I/xdYS2pt2Eb0Fr0EhianUSZlR6SM84V1ZSGLzZJVZqxAKo9OcoTO8KFd5SnbRjv5B3AOarbeXcbwbJ4g==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.14.0.tgz",
+      "integrity": "sha512-svIeleEBGQTAgeWaTySUgzba3rsEUGNaDN11B6wGvDjAyI59R/JkhM1+a7TP3T19v8+Ik+F/nzTz/AB6xJxQIA==",
       "cpu": [
         "arm64"
       ],
@@ -2522,9 +2522,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-gnu": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.13.1.tgz",
-      "integrity": "sha512-E0Ywt7jBjx35R5Rzd3RtPUcoPkvfef5Zp/HWvIYlTQHMkvG2e5An0qNktF+MV0Z+c5C2/7KT/3Hnb1rB3+JPsw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.14.0.tgz",
+      "integrity": "sha512-UQTedZ9FJJ59pk4fFxBF6rPOoPssRf9580kCT1IkDowUavcAUMygfn3gtxfMtEOCTHsGpPHXLGmd5ICZOzmRbg==",
       "cpu": [
         "x64"
       ],
@@ -2538,9 +2538,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-musl": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.13.1.tgz",
-      "integrity": "sha512-0s4a4laI8ND21X0dOn0d0rJNGHRV+8XpXehk/Cg7/FMzWK/5z4PO/rtJ2S/+r/A9VOM+AOKZkjgxKOMtW96qOQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.14.0.tgz",
+      "integrity": "sha512-3Od2QCu68nDzvTE9rSNvMmAq1VkMwY94I/38ZwQqONdqGnBYCTKpBaMR2guxcky8Pn4sKVnILHwUgqb8jnLvTw==",
       "cpu": [
         "x64"
       ],
@@ -2554,9 +2554,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-arm64-msvc": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.13.1.tgz",
-      "integrity": "sha512-jJ5v/jYDj9XGCorHnMzh2+W5vb+elqf87jW9o6JT7TXlm0g+sPFx+oDg4qaLXVoHJDMlHBrn7XDr0dpmjk7hbA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.14.0.tgz",
+      "integrity": "sha512-TRQh4pPdL2B34ihxYdDsxFgruk+u3opc+Spq6VMr/gwo+ASmEhVTxgnz/2RDEIlleXNYnxMCPI1LVyKiZgGn0w==",
       "cpu": [
         "arm64"
       ],
@@ -2567,9 +2567,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-x64-msvc": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.13.1.tgz",
-      "integrity": "sha512-jPMt5ji7igD7RMS/kn3gIYNnrl8iP47w7mYGK4zKn0xZbQNCSPYdhBMoAkEr5ivxen8O0c4Rxy7URp0AmN264Q==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.14.0.tgz",
+      "integrity": "sha512-bv7T2/l9S4x2Cf66MlFK647yHyNVfeNmeJt+8YHcuG1KbBLwCO47brQdbetqw3+UJKCr4usEc8rt8+Kl1LvnVA==",
       "cpu": [
         "x64"
       ],
@@ -3321,9 +3321,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
+      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -4317,9 +4317,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -4707,9 +4707,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
-      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-25 23:48 EDT — pi-research-runtime-integrity-0.3.44
+
+- Objective: Repair five reproduced Pi research-runtime defects and qualify LiteParse `2.14.0` without adopting unrelated package churn.
+- Reproduced: Aborting during tool execution made a second model call and consumed queued research input; OpenAI Responses compaction sent `tool_choice` without tools; structured reasoning reparsed its full accumulated signature per delta; `8192`-token models compacted empty context under fixed budgets; empty and file-list-only summaries could replace research history.
+- Document intake: Official LiteParse `2.14.0` bounds OCR raster memory to worker-sized rounds and removes quadratic bounding-box/layout work, directly improving long and dense paper ingestion.
+- Changed: Exact Pi `0.84.2` patchers now preserve queued input on tool-time abort, serialize accumulated reasoning once per block, omit no-tool Responses `tool_choice`, derive viable small-context compaction budgets, and reject structurally unusable history, split-turn, and branch checkpoints. The root and runtime locks now pin all seven LiteParse `2.14.0` platform packages.
+- Adversarial repair: Follow-up review blocked tiny structured stubs relative to current and prior checkpoint size, preserved documented branch replacement prompts, made all seven runtime native LiteParse locks fail closed on identity and platform drift, and required the load-bearing size-threshold formula in source verification.
+- Verified locally: Focused executable regressions passed after integration; the final full suite passed `951/951`; typecheck, build, architecture, website lint/typecheck/build (`34` pages), root/runtime/site production audits, source artifact verification, freshness review, and diff checks passed. Terminal dry and real packs matched at `116,527,953` bytes / `29,184` files with SHA-256 `f75b0511d86e244f5f6f42c75164c43524ce626f8b9fd3718e2a1f5b8414cdaf`; the exact clean consumer passed audits, package/runtime/provider/tool checks, and installed LiteParse parse/search/screenshot verification.
+- Preservation: Root work started from clean synchronized `main` at `aeb0a049`; the independent nested `website` checkout remains preserved at `67186845`, with only the root-owned release page intentionally updated for this candidate.
+- State: `verified` for the uncommitted local candidate; exact committed-SHA Daytona, PR CI, merge, publication, and post-release identity remain `unverified`. Next: commit the exact tree, run clean-machine proof, then merge, publish, and reconcile `0.3.44`.
+
 ### 2026-08-25 22:32 EDT — pi-subagents-legacy-install-0.3.43-release
 
 - Persistence: PR `#256` merged from exact tested head `84215bef3f13301cd448412b3bef05b59b2ca9ac` as `39eec7a0e245464bdfa765e7361193385c0f5ba2`; the release branch was deleted and pruned.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,30 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.44 - 2026-08-26
+
+### Research continuity
+
+- Stopping a tool run now ends the active Pi loop before queued steering or follow-up research input can be drained into an already-aborted model call. The queued input remains available for the next turn instead of producing a second spurious cancellation.
+
+### Compaction integrity
+
+- Small-context local and proxy models now bound compaction reserve and retained-history budgets to the model's actual context window, preventing empty or short sessions from compacting continuously.
+- Empty or structurally unusable summaries no longer replace research history. OpenAI Responses providers such as Grok also omit `tool_choice` when a compaction request has no tools.
+
+### Model reliability
+
+- OpenAI-compatible structured reasoning deltas are accumulated without reparsing and reserializing the complete history for every streamed detail, preventing long reasoning streams from blocking the event loop while preserving same-model replay.
+
+### Document research
+
+- Updated the bundled LiteParse runtime to `2.14.0`. OCR rasterization now runs in bounded worker-sized rounds, and dense PDF layout deduplication avoids quadratic work. Existing parse, search, and screenshot interfaces are unchanged.
+
+### Validation
+
+- Added executable abort-queue, Responses payload, structured-reasoning scale, small-context compaction, and summary-usability regressions across the maintained Pi runtime.
+- Re-ran installed document parsing, page-count, search, screenshot, package-artifact, runtime, and clean-consumer verification against LiteParse `2.14.0`.
+
 ## v0.3.43 - 2026-08-25
 
 ### Installation reliability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.43",
+      "version": "0.3.44",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",
@@ -76,13 +76,13 @@
         "node": ">=22.22.0 <26"
       },
       "optionalDependencies": {
-        "@llamaindex/liteparse-darwin-arm64": "2.13.1",
-        "@llamaindex/liteparse-darwin-x64": "2.13.1",
-        "@llamaindex/liteparse-linux-arm64-gnu": "2.13.1",
-        "@llamaindex/liteparse-linux-x64-gnu": "2.13.1",
-        "@llamaindex/liteparse-linux-x64-musl": "2.13.1",
-        "@llamaindex/liteparse-win32-arm64-msvc": "2.13.1",
-        "@llamaindex/liteparse-win32-x64-msvc": "2.13.1"
+        "@llamaindex/liteparse-darwin-arm64": "2.14.0",
+        "@llamaindex/liteparse-darwin-x64": "2.14.0",
+        "@llamaindex/liteparse-linux-arm64-gnu": "2.14.0",
+        "@llamaindex/liteparse-linux-x64-gnu": "2.14.0",
+        "@llamaindex/liteparse-linux-x64-musl": "2.14.0",
+        "@llamaindex/liteparse-win32-arm64-msvc": "2.14.0",
+        "@llamaindex/liteparse-win32-x64-msvc": "2.14.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -3874,9 +3874,9 @@
       }
     },
     "node_modules/@llamaindex/liteparse-darwin-arm64": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.13.1.tgz",
-      "integrity": "sha512-twznsLWeUD0QtSmZjjEQOZF/opFjJORbSILLNz41eM4PP0O2WT87ZAdUxLnPiA7JPZ6TdfoEc9lvAJfQPUHNig==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-arm64/-/liteparse-darwin-arm64-2.14.0.tgz",
+      "integrity": "sha512-waYoHguqomVv43KEEqNf6nWSrpfMnNC8LXRtgN+a7F/WwICfNzrgA5Z8ayj2jhvvpYv7tsJ25M1vl8bb0i5UlA==",
       "cpu": [
         "arm64"
       ],
@@ -3887,9 +3887,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-darwin-x64": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.13.1.tgz",
-      "integrity": "sha512-Im0RwZCztuK+x+may8QRvtFhk1rfGtVMYHvKRHXh+NG+reWFKCTpUkOGrlrW5ik4lu3nzd4Svjbg015zw8zCRQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-darwin-x64/-/liteparse-darwin-x64-2.14.0.tgz",
+      "integrity": "sha512-akTk/e6eEHgeP14f+8QiqueiEjiHTutX03XxRizXNn2aoTtQCEfElN4/p0rwTSFq35E76N7/z3ZVP5l1h4G4pw==",
       "cpu": [
         "x64"
       ],
@@ -3900,9 +3900,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-arm64-gnu": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.13.1.tgz",
-      "integrity": "sha512-L0n95I/xdYS2pt2Eb0Fr0EhianUSZlR6SM84V1ZSGLzZJVZqxAKo9OcoTO8KFd5SnbRjv5B3AOarbeXcbwbJ4g==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-arm64-gnu/-/liteparse-linux-arm64-gnu-2.14.0.tgz",
+      "integrity": "sha512-svIeleEBGQTAgeWaTySUgzba3rsEUGNaDN11B6wGvDjAyI59R/JkhM1+a7TP3T19v8+Ik+F/nzTz/AB6xJxQIA==",
       "cpu": [
         "arm64"
       ],
@@ -3916,9 +3916,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-gnu": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.13.1.tgz",
-      "integrity": "sha512-E0Ywt7jBjx35R5Rzd3RtPUcoPkvfef5Zp/HWvIYlTQHMkvG2e5An0qNktF+MV0Z+c5C2/7KT/3Hnb1rB3+JPsw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-gnu/-/liteparse-linux-x64-gnu-2.14.0.tgz",
+      "integrity": "sha512-UQTedZ9FJJ59pk4fFxBF6rPOoPssRf9580kCT1IkDowUavcAUMygfn3gtxfMtEOCTHsGpPHXLGmd5ICZOzmRbg==",
       "cpu": [
         "x64"
       ],
@@ -3932,9 +3932,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-linux-x64-musl": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.13.1.tgz",
-      "integrity": "sha512-0s4a4laI8ND21X0dOn0d0rJNGHRV+8XpXehk/Cg7/FMzWK/5z4PO/rtJ2S/+r/A9VOM+AOKZkjgxKOMtW96qOQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-linux-x64-musl/-/liteparse-linux-x64-musl-2.14.0.tgz",
+      "integrity": "sha512-3Od2QCu68nDzvTE9rSNvMmAq1VkMwY94I/38ZwQqONdqGnBYCTKpBaMR2guxcky8Pn4sKVnILHwUgqb8jnLvTw==",
       "cpu": [
         "x64"
       ],
@@ -3948,9 +3948,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-arm64-msvc": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.13.1.tgz",
-      "integrity": "sha512-jJ5v/jYDj9XGCorHnMzh2+W5vb+elqf87jW9o6JT7TXlm0g+sPFx+oDg4qaLXVoHJDMlHBrn7XDr0dpmjk7hbA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-arm64-msvc/-/liteparse-win32-arm64-msvc-2.14.0.tgz",
+      "integrity": "sha512-TRQh4pPdL2B34ihxYdDsxFgruk+u3opc+Spq6VMr/gwo+ASmEhVTxgnz/2RDEIlleXNYnxMCPI1LVyKiZgGn0w==",
       "cpu": [
         "arm64"
       ],
@@ -3961,9 +3961,9 @@
       ]
     },
     "node_modules/@llamaindex/liteparse-win32-x64-msvc": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.13.1.tgz",
-      "integrity": "sha512-jPMt5ji7igD7RMS/kn3gIYNnrl8iP47w7mYGK4zKn0xZbQNCSPYdhBMoAkEr5ivxen8O0c4Rxy7URp0AmN264Q==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/liteparse-win32-x64-msvc/-/liteparse-win32-x64-msvc-2.14.0.tgz",
+      "integrity": "sha512-bv7T2/l9S4x2Cf66MlFK647yHyNVfeNmeJt+8YHcuG1KbBLwCO47brQdbetqw3+UJKCr4usEc8rt8+Kl1LvnVA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",
@@ -196,12 +196,12 @@
   },
   "author": "",
   "optionalDependencies": {
-    "@llamaindex/liteparse-darwin-arm64": "2.13.1",
-    "@llamaindex/liteparse-darwin-x64": "2.13.1",
-    "@llamaindex/liteparse-linux-arm64-gnu": "2.13.1",
-    "@llamaindex/liteparse-linux-x64-gnu": "2.13.1",
-    "@llamaindex/liteparse-linux-x64-musl": "2.13.1",
-    "@llamaindex/liteparse-win32-arm64-msvc": "2.13.1",
-    "@llamaindex/liteparse-win32-x64-msvc": "2.13.1"
+    "@llamaindex/liteparse-darwin-arm64": "2.14.0",
+    "@llamaindex/liteparse-darwin-x64": "2.14.0",
+    "@llamaindex/liteparse-linux-arm64-gnu": "2.14.0",
+    "@llamaindex/liteparse-linux-x64-gnu": "2.14.0",
+    "@llamaindex/liteparse-linux-x64-musl": "2.14.0",
+    "@llamaindex/liteparse-win32-arm64-msvc": "2.14.0",
+    "@llamaindex/liteparse-win32-x64-msvc": "2.14.0"
   }
 }

--- a/scripts/lib/liteparse-release-contract.d.mts
+++ b/scripts/lib/liteparse-release-contract.d.mts
@@ -1,0 +1,21 @@
+export declare const FEYNMAN_LITEPARSE_GIT_HEAD: string;
+export declare const FEYNMAN_LITEPARSE_VERSION: string;
+export declare const FEYNMAN_LITEPARSE_INTEGRITY: string;
+export declare const FEYNMAN_LITEPARSE_NATIVE_INTEGRITIES: Readonly<Record<string, string>>;
+export declare const FEYNMAN_LITEPARSE_NATIVE_PACKAGES: readonly string[];
+export declare const FEYNMAN_LITEPARSE_NATIVE_PLATFORMS: Readonly<
+	Record<string, { cpu: readonly string[]; os: readonly string[]; libc?: readonly string[] }>
+>;
+export declare function verifyLiteparseManifestContract(
+	manifest: Record<string, unknown>,
+	fail: (message: string) => never,
+	label: string,
+): void;
+export declare function verifyLiteparseRootLockContract(
+	rootLock: Record<string, unknown>,
+	fail: (message: string) => never,
+): void;
+export declare function verifyLiteparseRuntimeLockContract(
+	runtimeLock: Record<string, unknown>,
+	fail: (message: string) => never,
+): void;

--- a/scripts/lib/liteparse-release-contract.mjs
+++ b/scripts/lib/liteparse-release-contract.mjs
@@ -1,0 +1,110 @@
+export const FEYNMAN_LITEPARSE_GIT_HEAD =
+	"b75603d44027cc70c44a9d9f9f20458c93fd37a7";
+export const FEYNMAN_LITEPARSE_VERSION = "2.14.0";
+export const FEYNMAN_LITEPARSE_INTEGRITY =
+	"sha512-lIFBbTRs87Bpp45Lm986hUDEPndm85pT9l/BM1dtWhQs0zTLEkpHLrgbOxGG2rjBqDgJM5fdChT8LWUd4ZThWA==";
+export const FEYNMAN_LITEPARSE_NATIVE_INTEGRITIES = Object.freeze({
+	"@llamaindex/liteparse-darwin-arm64":
+		"sha512-waYoHguqomVv43KEEqNf6nWSrpfMnNC8LXRtgN+a7F/WwICfNzrgA5Z8ayj2jhvvpYv7tsJ25M1vl8bb0i5UlA==",
+	"@llamaindex/liteparse-darwin-x64":
+		"sha512-akTk/e6eEHgeP14f+8QiqueiEjiHTutX03XxRizXNn2aoTtQCEfElN4/p0rwTSFq35E76N7/z3ZVP5l1h4G4pw==",
+	"@llamaindex/liteparse-linux-arm64-gnu":
+		"sha512-svIeleEBGQTAgeWaTySUgzba3rsEUGNaDN11B6wGvDjAyI59R/JkhM1+a7TP3T19v8+Ik+F/nzTz/AB6xJxQIA==",
+	"@llamaindex/liteparse-linux-x64-gnu":
+		"sha512-UQTedZ9FJJ59pk4fFxBF6rPOoPssRf9580kCT1IkDowUavcAUMygfn3gtxfMtEOCTHsGpPHXLGmd5ICZOzmRbg==",
+	"@llamaindex/liteparse-linux-x64-musl":
+		"sha512-3Od2QCu68nDzvTE9rSNvMmAq1VkMwY94I/38ZwQqONdqGnBYCTKpBaMR2guxcky8Pn4sKVnILHwUgqb8jnLvTw==",
+	"@llamaindex/liteparse-win32-arm64-msvc":
+		"sha512-TRQh4pPdL2B34ihxYdDsxFgruk+u3opc+Spq6VMr/gwo+ASmEhVTxgnz/2RDEIlleXNYnxMCPI1LVyKiZgGn0w==",
+	"@llamaindex/liteparse-win32-x64-msvc":
+		"sha512-bv7T2/l9S4x2Cf66MlFK647yHyNVfeNmeJt+8YHcuG1KbBLwCO47brQdbetqw3+UJKCr4usEc8rt8+Kl1LvnVA==",
+});
+export const FEYNMAN_LITEPARSE_NATIVE_PACKAGES = Object.freeze(
+	Object.keys(FEYNMAN_LITEPARSE_NATIVE_INTEGRITIES),
+);
+export const FEYNMAN_LITEPARSE_NATIVE_PLATFORMS = Object.freeze({
+	"@llamaindex/liteparse-darwin-arm64": { cpu: ["arm64"], os: ["darwin"] },
+	"@llamaindex/liteparse-darwin-x64": { cpu: ["x64"], os: ["darwin"] },
+	"@llamaindex/liteparse-linux-arm64-gnu": {
+		cpu: ["arm64"],
+		os: ["linux"],
+		libc: ["glibc"],
+	},
+	"@llamaindex/liteparse-linux-x64-gnu": {
+		cpu: ["x64"],
+		os: ["linux"],
+		libc: ["glibc"],
+	},
+	"@llamaindex/liteparse-linux-x64-musl": {
+		cpu: ["x64"],
+		os: ["linux"],
+		libc: ["musl"],
+	},
+	"@llamaindex/liteparse-win32-arm64-msvc": { cpu: ["arm64"], os: ["win32"] },
+	"@llamaindex/liteparse-win32-x64-msvc": { cpu: ["x64"], os: ["win32"] },
+});
+
+function verifyLiteparseNativeLockEntries(lock, fail, label) {
+	for (const packageName of FEYNMAN_LITEPARSE_NATIVE_PACKAGES) {
+		const entry = lock.packages?.[`node_modules/${packageName}`];
+		const platform = FEYNMAN_LITEPARSE_NATIVE_PLATFORMS[packageName];
+		if (
+			entry?.version !== FEYNMAN_LITEPARSE_VERSION ||
+			entry?.resolved !==
+				`https://registry.npmjs.org/${packageName}/-/${packageName.slice("@llamaindex/".length)}-${FEYNMAN_LITEPARSE_VERSION}.tgz` ||
+			entry?.integrity !== FEYNMAN_LITEPARSE_NATIVE_INTEGRITIES[packageName] ||
+			entry?.optional !== true ||
+			JSON.stringify(entry.cpu) !== JSON.stringify(platform.cpu) ||
+			JSON.stringify(entry.os) !== JSON.stringify(platform.os) ||
+			JSON.stringify(entry.libc) !== JSON.stringify(platform.libc)
+		) {
+			fail(`${label} does not resolve exact ${packageName}@${FEYNMAN_LITEPARSE_VERSION}`);
+		}
+	}
+}
+
+export function verifyLiteparseManifestContract(manifest, fail, label) {
+	if (manifest.version !== FEYNMAN_LITEPARSE_VERSION) {
+		fail(`${label} LiteParse is not ${FEYNMAN_LITEPARSE_VERSION}`);
+	}
+	const nativePackages = Object.keys(manifest.optionalDependencies ?? {})
+		.filter((packageName) => packageName.startsWith("@llamaindex/liteparse-"))
+		.sort();
+	if (
+		JSON.stringify(nativePackages) !==
+		JSON.stringify(FEYNMAN_LITEPARSE_NATIVE_PACKAGES.toSorted())
+	) {
+		fail(`${label} LiteParse does not declare the reviewed seven native packages`);
+	}
+	for (const packageName of FEYNMAN_LITEPARSE_NATIVE_PACKAGES) {
+		if (manifest.optionalDependencies?.[packageName] !== FEYNMAN_LITEPARSE_VERSION) {
+			fail(`${label} LiteParse optional package ${packageName} is not ${FEYNMAN_LITEPARSE_VERSION}`);
+		}
+	}
+}
+
+export function verifyLiteparseRootLockContract(rootLock, fail) {
+	for (const packageName of FEYNMAN_LITEPARSE_NATIVE_PACKAGES) {
+		if (
+			rootLock.packages?.[""]?.optionalDependencies?.[packageName] !==
+			FEYNMAN_LITEPARSE_VERSION
+		) {
+			fail(`package-lock.json does not request ${packageName} ${FEYNMAN_LITEPARSE_VERSION}`);
+		}
+	}
+	verifyLiteparseNativeLockEntries(rootLock, fail, "package-lock.json");
+}
+
+export function verifyLiteparseRuntimeLockContract(runtimeLock, fail) {
+	const entry = runtimeLock.packages?.["node_modules/@llamaindex/liteparse"];
+	if (
+		entry?.version !== FEYNMAN_LITEPARSE_VERSION ||
+		entry?.resolved !==
+			`https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-${FEYNMAN_LITEPARSE_VERSION}.tgz` ||
+		entry?.integrity !== FEYNMAN_LITEPARSE_INTEGRITY
+	) {
+		fail(`committed runtime lock does not resolve exact LiteParse ${FEYNMAN_LITEPARSE_VERSION}`);
+	}
+	verifyLiteparseManifestContract(entry, fail, "committed runtime lock");
+	verifyLiteparseNativeLockEntries(runtimeLock, fail, "committed runtime lock");
+}

--- a/scripts/lib/pi-agent-core-patch.mjs
+++ b/scripts/lib/pi-agent-core-patch.mjs
@@ -7,9 +7,18 @@
  *
  * This deliberately ports only the research-session continuity fix from issue
  * #8331 / closed PR #8593, not its enabled default or adjacent coding-agent UI.
+ * It also ports only the post-turn abort guard from closed upstream PR #8658
+ * (head daad15954920894581c59ced4cae7c295f755e45), adapted to Pi 0.84.2's
+ * optional AbortSignal.
+ *
  * Removal condition: adopt a released Pi watchdog that is safe for silent local
- * prefills and settles without awaiting a non-cooperative provider iterator.
+ * prefills and settles without awaiting a non-cooperative provider iterator,
+ * and which preserves queued steering/follow-up input after a tool-time abort.
  */
+
+const PI_AGENT_CORE_PATCH_REQUIRED_VERSION = "0.84.2";
+const ABORT_QUEUE_GUARD_MARKER =
+	`Feynman Pi ${PI_AGENT_CORE_PATCH_REQUIRED_VERSION} forward patch: preserve queued input on abort #8658`;
 
 export const PI_AGENT_CORE_PATCH_MARKERS = Object.freeze({
 	toolAliases: "function normalizeFeynmanToolAlias(",
@@ -154,6 +163,19 @@ const PATCHED_STREAM_TIMEOUT_CONFIG =
 const LEGACY_STREAM_TIMEOUT_CONFIG =
 	'    const configured = parseFeynmanStreamIdleTimeoutMs(config.streamIdleTimeoutMs, "streamIdleTimeoutMs");';
 
+const ORIGINAL_POST_TURN_SEQUENCE = `            await emit({ type: "turn_end", message, toolResults });
+            const nextTurnContext = {`;
+
+const PATCHED_POST_TURN_SEQUENCE = `            await emit({ type: "turn_end", message, toolResults });
+            // ${ABORT_QUEUE_GUARD_MARKER}
+            // Stop before prepareNextTurn or either queue callback. The owning
+            // Agent/session can then restore the untouched queued input.
+            if (signal?.aborted) {
+                await emit({ type: "agent_end", messages: newMessages });
+                return;
+            }
+            const nextTurnContext = {`;
+
 const PATCHED_STREAM_LOOP = `    let partialMessage = null;
     let addedPartial = false;
     const iterator = response[Symbol.asyncIterator]();
@@ -227,6 +249,10 @@ ${PATCHED_STREAM_NEXT_SEQUENCE}
             break;
         const event = settled.value;`;
 
+function countOccurrences(source, fragment) {
+	return source.split(fragment).length - 1;
+}
+
 function stripStaleSourceMapDirective(source) {
 	const marker = "//# sourceMappingURL=";
 	const first = source.indexOf(marker);
@@ -276,6 +302,22 @@ export function assertPiAgentCorePatchSource(source, surface = "Pi AgentCore") {
 	}
 	if (source.includes("//# sourceMappingURL=")) {
 		throw new Error(`Incomplete ${surface} patch: retained stale source map directive`);
+	}
+	const hasAgentLoopSurface =
+		source.includes("function createAgentStream()") ||
+		source.includes("async function runLoop(") ||
+		source.includes(ABORT_QUEUE_GUARD_MARKER);
+	if (hasAgentLoopSurface) {
+		if (countOccurrences(source, PATCHED_POST_TURN_SEQUENCE) !== 1) {
+			throw new Error(
+				`Incomplete ${surface} patch: missing exact post-turn abort queue guard`,
+			);
+		}
+		if (source.includes(ORIGINAL_POST_TURN_SEQUENCE)) {
+			throw new Error(
+				`Incomplete ${surface} patch: retained unguarded post-turn queue path`,
+			);
+		}
 	}
 }
 
@@ -381,10 +423,33 @@ function patchStreamWatchdog(source) {
 	return patched;
 }
 
+function patchAbortQueueGuard(source) {
+	// Unit fixtures that exercise only the stream/tool transforms intentionally
+	// omit runLoop. Real Pi AgentCore sources must match the exact 0.84.2 layout.
+	const hasAgentLoopSurface =
+		source.includes("function createAgentStream()") ||
+		source.includes("async function runLoop(") ||
+		source.includes(ABORT_QUEUE_GUARD_MARKER);
+	if (!hasAgentLoopSurface) {
+		return source;
+	}
+	if (source.includes(ABORT_QUEUE_GUARD_MARKER)) {
+		return source;
+	}
+	const occurrences = countOccurrences(source, ORIGINAL_POST_TURN_SEQUENCE);
+	if (occurrences !== 1) {
+		throw new Error(
+			`Unsupported Pi ${PI_AGENT_CORE_PATCH_REQUIRED_VERSION} AgentCore abort queue layout; expected 1 occurrence, found ${occurrences}`,
+		);
+	}
+	return source.replace(ORIGINAL_POST_TURN_SEQUENCE, PATCHED_POST_TURN_SEQUENCE);
+}
+
 export function patchPiAgentCoreSource(source) {
 	let patched = stripStaleSourceMapDirective(source);
 	patched = patchToolAliases(patched);
 	patched = patchStreamWatchdog(patched);
+	patched = patchAbortQueueGuard(patched);
 	assertPiAgentCorePatchSource(patched);
 	return patched;
 }

--- a/scripts/lib/pi-ai-forward-fixes-patch.mjs
+++ b/scripts/lib/pi-ai-forward-fixes-patch.mjs
@@ -3,6 +3,11 @@ import {
 	isPiOpenAiStructuredReasoningPatched,
 	patchPiOpenAiStructuredReasoningSource,
 } from "./pi-openai-reasoning-patch.mjs";
+import {
+	assertPiOpenAiResponsesNoToolsSource,
+	PI_OPENAI_RESPONSES_NO_TOOLS_MARKER,
+	patchPiOpenAiResponsesNoToolsSource,
+} from "./pi-openai-responses-no-tools-patch.mjs";
 
 /**
  * Temporary Pi 0.84.2 forward patches for upstream commits:
@@ -18,10 +23,11 @@ import {
  * - 4ca636c5e07eb1e0fbc6be6c11c720d1a8856daa (structured reasoning details)
  * - b7bb00b936dbe21b8e160b3e89efdec361846699 (reasoning signature storage)
  * - c5ad7c1b0f7623bbfdf64dd4967fa6e99c15c01a (reasoning delta concatenation)
+ * - 7280f89b42e4b233afc4f18e41366e845d179cef (Responses no-tools contract, Pi #8649/#8650)
  * - https://github.com/earendil-works/pi/issues/8507 (transient OpenRouter budget retry)
  *
  * Removal condition: delete this patch after Feynman adopts a released Pi
- * version that contains all thirteen fixes.
+ * version that contains all fourteen fixes.
  */
 
 export const PI_AI_FORWARD_FIX_REQUIRED_VERSION = "0.84.2";
@@ -60,6 +66,7 @@ export const PI_AI_FORWARD_FIX_MARKERS = Object.freeze({
 	bedrock: "Feynman Pi 0.84.2 forward patch: Bedrock Smithy response headers",
 	toolChoice: "Feynman Pi 0.84.2 forward patch: provider-neutral tool choice",
 	openAiCompletions: "Feynman Pi 0.84.2 forward patch: Gemini signatures and bounded tool IDs",
+	openAiResponsesNoTools: PI_OPENAI_RESPONSES_NO_TOOLS_MARKER,
 	providerRetry: "Feynman Pi 0.84.2 forward patch: transient in-flight budget retry #8507",
 });
 
@@ -478,7 +485,9 @@ export function assertPiAiForwardFixSource(relativePath, source) {
 		case "dist/api/azure-openai-responses.js":
 		case "dist/api/mistral-conversations.js":
 		case "dist/api/openai-codex-responses.js":
+			return;
 		case "dist/api/openai-responses.js":
+			assertPiOpenAiResponsesNoToolsSource(source, relativePath);
 			return;
 		default:
 			throw new Error(`Unknown Pi AI forward patch target: ${relativePath}`);
@@ -667,6 +676,11 @@ function patchOpenAiCompletions(source) {
 		if (isPiOpenAiStructuredReasoningPatched(source)) {
 			assertPiAiForwardFixSource(relativePath, source);
 			return source;
+		}
+		if (source.includes("function isReasoningDetailObject(detail) {")) {
+			const upgraded = patchPiOpenAiStructuredReasoningSource(source);
+			assertPiAiForwardFixSource(relativePath, upgraded);
+			return upgraded;
 		}
 		let upgraded = source
 			.replaceAll("output.reasoning_details", "output.reasoningDetails")
@@ -1171,7 +1185,9 @@ export function patchPiAiForwardFixSource(relativePath, source) {
 		case "dist/api/azure-openai-responses.js":
 		case "dist/api/mistral-conversations.js":
 		case "dist/api/openai-codex-responses.js":
+			break;
 		case "dist/api/openai-responses.js":
+			patched = patchPiOpenAiResponsesNoToolsSource(patched, relativePath);
 			break;
 		default:
 			throw new Error(`Unknown Pi AI forward patch target: ${relativePath}`);

--- a/scripts/lib/pi-ai-forward-fixes-verifier.mjs
+++ b/scripts/lib/pi-ai-forward-fixes-verifier.mjs
@@ -341,6 +341,34 @@ export async function verifyRuntimeForwardFixBehavior(packageRoot, { prunedNativ
 	assert.equal("tool_choice" in compactionPayload, false);
 	assert.equal("tools" in compactionPayload, false);
 
+	const openAiResponses = await import(
+		`${pathToFileURL(resolve(piAiRoot, "dist", "api", "openai-responses.js")).href}?installed-forward-fix=${Date.now()}`
+	);
+	const responsesModel = {
+		...openAiModel,
+		id: "grok-4.6-installed-verifier",
+		name: "grok-4.6-installed-verifier",
+		api: "openai-responses",
+		provider: "xai",
+		baseUrl: "https://api.x.ai/v1",
+	};
+	let responsesPayload;
+	const responsesResult = await openAiResponses.streamSimple(
+		responsesModel,
+		{ messages: [{ role: "user", content: "summarize", timestamp: 0 }] },
+		{
+			apiKey: "test",
+			toolChoice: "none",
+			onPayload: (payload) => {
+				responsesPayload = payload;
+				throw new Error("installed Responses payload captured");
+			},
+		},
+	).result();
+	assert.match(responsesResult.errorMessage ?? "", /installed Responses payload captured/);
+	assert.equal("tool_choice" in responsesPayload, false);
+	assert.equal("tools" in responsesPayload, false);
+
 	const providerRetry = await import(
 		`${pathToFileURL(resolve(piAiRoot, "dist", "utils", "provider-retry.js")).href}?installed-forward-fix=${Date.now()}`
 	);

--- a/scripts/lib/pi-compaction-tools-patch.d.mts
+++ b/scripts/lib/pi-compaction-tools-patch.d.mts
@@ -9,6 +9,12 @@ export declare const PI_COMPACTION_TOOLS_PATCH_MARKERS: Readonly<{
 	branchResponse: string;
 	summaryFailure: string;
 	summaryFailureTypes: string;
+	contextBudgets: string;
+	contextCallers: string;
+	contextBudgetTypes: string;
+	summaryIntegrity: string;
+	branchIntegrity: string;
+	summaryIntegrityTypes: string;
 }>;
 export declare function assertPiCompactionToolsPatchedSource(relativePath: string, source: string): void;
 export declare function patchPiCompactionToolsSource(relativePath: string, source: string): string;

--- a/scripts/lib/pi-compaction-tools-patch.mjs
+++ b/scripts/lib/pi-compaction-tools-patch.mjs
@@ -1,10 +1,12 @@
 /**
- * Temporary Pi 0.84.2 forward patch for upstream commits:
+ * Temporary Pi 0.84.2 forward patch for upstream commits and issue-scoped fixes:
  * - 90305d90a049d3f7784f15821d117fc6932248e7 (disable tools during summaries)
  * - 97fa14e39cfce78c273a36b2d9e8509cd5bc6b72 (reject truncated summaries)
+ * - earendil-works/pi#8651 (bound compaction budgets to the model context window)
+ * - earendil-works/pi#8652 (reject unusable persisted summary checkpoints)
  *
  * Removal condition: delete this patch after Feynman adopts a released Pi
- * version that contains the commits above.
+ * version that contains the commits above and equivalent fixes for #8651/#8652.
  */
 
 export const PI_COMPACTION_TOOLS_REQUIRED_VERSION = "0.84.2";
@@ -12,6 +14,7 @@ export const PI_COMPACTION_TOOLS_REQUIRED_VERSION = "0.84.2";
 export const PI_COMPACTION_TOOLS_RUNTIME_TARGETS = Object.freeze([
 	"dist/core/compaction/compaction.js",
 	"dist/core/compaction/branch-summarization.js",
+	"dist/core/agent-session.js",
 ]);
 export const PI_COMPACTION_TOOLS_TYPE_TARGETS = Object.freeze([
 	"dist/core/compaction/compaction.d.ts",
@@ -28,20 +31,30 @@ export const PI_COMPACTION_TOOLS_PATCH_MARKERS = Object.freeze({
 	branchResponse: "Feynman Pi 0.84.2 forward patch: reject branch-summary tool calls",
 	summaryFailure: "Feynman Pi 0.84.2 forward patch: reject truncated summaries",
 	summaryFailureTypes: "Feynman Pi 0.84.2 forward patch: type truncated-summary guard",
+	contextBudgets: "Feynman Pi 0.84.2 hotfix: bound compaction budgets to model context",
+	contextCallers: "Feynman Pi 0.84.2 hotfix: pass model context into compaction preparation",
+	contextBudgetTypes: "Feynman Pi 0.84.2 hotfix: type model-bounded compaction budgets",
+	summaryIntegrity: "Feynman Pi 0.84.2 hotfix: reject unusable summary checkpoints",
+	branchIntegrity: "Feynman Pi 0.84.2 hotfix: reject unusable branch checkpoints",
+	summaryIntegrityTypes: "Feynman Pi 0.84.2 hotfix: type summary integrity guard",
 });
 
 function countOccurrences(source, fragment) {
 	return source.split(fragment).length - 1;
 }
 
-function replaceRequired(source, original, replacement, label) {
+function replaceRequiredOccurrences(source, original, replacement, label, expectedCount = 1) {
 	const count = countOccurrences(source, original);
-	if (count !== 1) {
+	if (count !== expectedCount) {
 		throw new Error(
-			`Unsupported Pi ${PI_COMPACTION_TOOLS_REQUIRED_VERSION} ${label} layout; expected 1 occurrence, found ${count}`,
+			`Unsupported Pi ${PI_COMPACTION_TOOLS_REQUIRED_VERSION} ${label} layout; expected ${expectedCount} occurrence${expectedCount === 1 ? "" : "s"}, found ${count}`,
 		);
 	}
-	return source.replace(original, replacement);
+	return source.split(original).join(replacement);
+}
+
+function replaceRequired(source, original, replacement, label) {
+	return replaceRequiredOccurrences(source, original, replacement, label, 1);
 }
 
 function assertFragments(source, relativePath, fragments) {
@@ -71,33 +84,101 @@ function stripStaleSourceMapDirective(source, sourceMapName, label) {
 	return count === 1 ? source.replace(directive, "") : source;
 }
 
+function isFullCompactionSource(source) {
+	return [
+		"export const DEFAULT_COMPACTION_SETTINGS",
+		"export function shouldCompact",
+		"export function prepareCompaction",
+	].some((fragment) => source.includes(fragment));
+}
+
+function isFullBranchSource(source) {
+	return source.includes("export async function generateBranchSummary");
+}
+
+function isFullCompactionTypesSource(source) {
+	return source.includes("export interface CompactionSettings") || source.includes("prepareCompaction(pathEntries:");
+}
+
 export function assertPiCompactionToolsPatchedSource(relativePath, source) {
 	switch (relativePath) {
-		case "dist/core/compaction/compaction.js":
+		case "dist/core/compaction/compaction.js": {
 			assertFragments(source, relativePath, [
 				PI_COMPACTION_TOOLS_PATCH_MARKERS.request,
 				PI_COMPACTION_TOOLS_PATCH_MARKERS.historyResponse,
 				PI_COMPACTION_TOOLS_PATCH_MARKERS.prefixResponse,
 				PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryFailure,
 				'        toolChoice: "none",',
-				'export function getSummarizationFailure(response, label) {',
+				"export function getSummarizationFailure(response, label) {",
 				'response.stopReason === "length"',
-				'generation hit the token cap and the summary is incomplete',
+				"generation hit the token cap and the summary is incomplete",
 				'throw new Error("Summarization attempted to call a tool");',
 				'throw new Error("Turn prefix summarization attempted to call a tool");',
 			]);
+			if (isFullCompactionSource(source)) {
+				assertFragments(source, relativePath, [
+					PI_COMPACTION_TOOLS_PATCH_MARKERS.contextBudgets,
+					PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryIntegrity,
+					"export function getEffectiveCompactionSettings(settings, contextWindow) {",
+					"const reserveCeiling = Math.max(1, Math.floor(windowTokens / 4));",
+					"const keepRecentCeiling = Math.max(1, windowTokens - 2 * reserveTokens);",
+					"return contextTokens > contextWindow - effectiveSettings.reserveTokens;",
+					"export function prepareCompaction(pathEntries, settings, contextWindow) {",
+					"findCutPoint(pathEntries, boundaryStart, boundaryEnd, effectiveSettings.keepRecentTokens)",
+					"settings: effectiveSettings,",
+					"export function getSummaryUsabilityFailure(summary, label, requiredSections = CHECKPOINT_REQUIRED_SECTIONS, sourceCharacters) {",
+					"return Math.min(512, Math.max(64, Math.floor(sourceCharacters / 200)));",
+					"const minimumCharacters = minimumSummaryContentCharacters(sourceCharacters);",
+					'getSummaryUsabilityFailure(textContent, "Summarization", undefined, conversationText.length + (previousSummary?.length ?? 0))',
+					'getSummaryUsabilityFailure(textContent, "Turn prefix summarization", TURN_PREFIX_REQUIRED_SECTIONS, conversationText.length)',
+				]);
+				assertAbsentFragments(source, relativePath, [
+					"return contextTokens > contextWindow - settings.reserveTokens;",
+					"findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens)",
+					"text: contentText(response.content),",
+				]);
+			}
 			assertAbsentFragments(source, relativePath, ["//# sourceMappingURL="]);
 			return;
-		case "dist/core/compaction/branch-summarization.js":
+		}
+		case "dist/core/compaction/branch-summarization.js": {
 			assertFragments(source, relativePath, [
 				PI_COMPACTION_TOOLS_PATCH_MARKERS.branchResponse,
-				'import { completeSummarization, estimateTokens, getSummarizationFailure } from "./compaction.js";',
 				'const failure = getSummarizationFailure(response, "Branch summarization");',
 				'return { error: "Branch summarization attempted to call a tool" };',
 			]);
+			if (isFullBranchSource(source)) {
+				assertFragments(source, relativePath, [
+					PI_COMPACTION_TOOLS_PATCH_MARKERS.contextBudgets,
+					PI_COMPACTION_TOOLS_PATCH_MARKERS.branchIntegrity,
+					"getEffectiveCompactionSettings",
+					"getSummaryUsabilityFailure",
+					"const effectiveSettings = getEffectiveCompactionSettings(",
+					"const tokenBudget = contextWindow - effectiveSettings.reserveTokens;",
+					'getSummaryUsabilityFailure(summary, "Branch summarization", replaceInstructions && customInstructions ? [] : undefined, conversationText.length)',
+				]);
+				assertAbsentFragments(source, relativePath, [
+					"const tokenBudget = contextWindow - reserveTokens;",
+				]);
+			} else {
+				assertFragments(source, relativePath, [
+					'import { completeSummarization, estimateTokens, getSummarizationFailure } from "./compaction.js";',
+				]);
+			}
 			assertAbsentFragments(source, relativePath, ["//# sourceMappingURL="]);
 			return;
-		case "dist/core/compaction/compaction.d.ts":
+		}
+		case "dist/core/agent-session.js":
+			assertFragments(source, relativePath, [PI_COMPACTION_TOOLS_PATCH_MARKERS.contextCallers]);
+			if (countOccurrences(source, PI_COMPACTION_TOOLS_PATCH_MARKERS.contextCallers) !== 2) {
+				throw new Error(`Incomplete Pi compaction tools patch ${relativePath}: expected two model-context call sites`);
+			}
+			if (countOccurrences(source, "prepareCompaction(pathEntries, settings, requestModel.contextWindow)") !== 2) {
+				throw new Error(`Incomplete Pi compaction tools patch ${relativePath}: model context is not wired to both compaction paths`);
+			}
+			assertAbsentFragments(source, relativePath, ["prepareCompaction(pathEntries, settings);"]);
+			return;
+		case "dist/core/compaction/compaction.d.ts": {
 			assertFragments(source, relativePath, [
 				PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryFailureTypes,
 				"export declare function getSummarizationFailure(",
@@ -105,8 +186,18 @@ export function assertPiCompactionToolsPatchedSource(relativePath, source) {
 				"label: string",
 				"): string | undefined;",
 			]);
+			if (isFullCompactionTypesSource(source)) {
+				assertFragments(source, relativePath, [
+					PI_COMPACTION_TOOLS_PATCH_MARKERS.contextBudgetTypes,
+					PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryIntegrityTypes,
+					"export declare function getEffectiveCompactionSettings(settings: CompactionSettings, contextWindow: number | undefined): CompactionSettings;",
+					"export declare function getSummaryUsabilityFailure(summary: string, label: string, requiredSections?: readonly string[], sourceCharacters?: number): string | undefined;",
+					"prepareCompaction(pathEntries: SessionEntry[], settings: CompactionSettings, contextWindow?: number)",
+				]);
+			}
 			assertAbsentFragments(source, relativePath, ["//# sourceMappingURL="]);
 			return;
+		}
 		default:
 			throw new Error(`Unknown Pi compaction tools patch target: ${relativePath}`);
 	}
@@ -117,53 +208,53 @@ function patchCompactionSource(source) {
 	if (!patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.request)) {
 		patched = replaceRequired(
 			patched,
-		[
-			"        cacheRetention: \"none\",",
-			"        sessionId: uuidv7(),",
-		].join("\n"),
-		[
-			"        cacheRetention: \"none\",",
-			"        sessionId: uuidv7(),",
-			`        // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.request}`,
-			'        toolChoice: "none",',
-		].join("\n"),
-		"summarization request options",
-	);
+			[
+				'        cacheRetention: "none",',
+				"        sessionId: uuidv7(),",
+			].join("\n"),
+			[
+				'        cacheRetention: "none",',
+				"        sessionId: uuidv7(),",
+				`        // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.request}`,
+				'        toolChoice: "none",',
+			].join("\n"),
+			"summarization request options",
+		);
 		patched = replaceRequired(
 			patched,
-		[
-			'        throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);',
-			"    }",
-			"    const textContent = contentText(response.content);",
-		].join("\n"),
-		[
-			'        throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);',
-			"    }",
-			`    // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.historyResponse}`,
-			'    if (response.content.some((block) => block.type === "toolCall")) {',
-			'        throw new Error("Summarization attempted to call a tool");',
-			"    }",
-			"    const textContent = contentText(response.content);",
-		].join("\n"),
-		"history summary response",
-	);
+			[
+				'        throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);',
+				"    }",
+				"    const textContent = contentText(response.content);",
+			].join("\n"),
+			[
+				'        throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);',
+				"    }",
+				`    // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.historyResponse}`,
+				'    if (response.content.some((block) => block.type === "toolCall")) {',
+				'        throw new Error("Summarization attempted to call a tool");',
+				"    }",
+				"    const textContent = contentText(response.content);",
+			].join("\n"),
+			"history summary response",
+		);
 		patched = replaceRequired(
 			patched,
-		[
-			'        throw new Error(`Turn prefix summarization failed: ${response.errorMessage || "Unknown error"}`);',
-			"    }",
-			"    return {",
-		].join("\n"),
-		[
-			'        throw new Error(`Turn prefix summarization failed: ${response.errorMessage || "Unknown error"}`);',
-			"    }",
-			`    // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.prefixResponse}`,
-			'    if (response.content.some((block) => block.type === "toolCall")) {',
-			'        throw new Error("Turn prefix summarization attempted to call a tool");',
-			"    }",
-			"    return {",
-		].join("\n"),
-		"turn-prefix summary response",
+			[
+				'        throw new Error(`Turn prefix summarization failed: ${response.errorMessage || "Unknown error"}`);',
+				"    }",
+				"    return {",
+			].join("\n"),
+			[
+				'        throw new Error(`Turn prefix summarization failed: ${response.errorMessage || "Unknown error"}`);',
+				"    }",
+				`    // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.prefixResponse}`,
+				'    if (response.content.some((block) => block.type === "toolCall")) {',
+				'        throw new Error("Turn prefix summarization attempted to call a tool");',
+				"    }",
+				"    return {",
+			].join("\n"),
+			"turn-prefix summary response",
 		);
 	}
 	if (!patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryFailure)) {
@@ -207,6 +298,233 @@ function createSummarizationOptions(`,
 			"turn-prefix summary failure",
 		);
 	}
+	if (isFullCompactionSource(patched) && !patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.contextBudgets)) {
+		patched = replaceRequired(
+			patched,
+			`export const DEFAULT_COMPACTION_SETTINGS = {
+    enabled: true,
+    reserveTokens: 16384,
+    keepRecentTokens: 20000,
+};`,
+			`export const DEFAULT_COMPACTION_SETTINGS = {
+    enabled: true,
+    reserveTokens: 16384,
+    keepRecentTokens: 20000,
+};
+// ${PI_COMPACTION_TOOLS_PATCH_MARKERS.contextBudgets}
+export function getEffectiveCompactionSettings(settings, contextWindow) {
+    if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
+        return settings;
+    }
+    const windowTokens = Math.max(4, Math.floor(contextWindow));
+    const configuredReserve = Number.isFinite(settings.reserveTokens) && settings.reserveTokens > 0
+        ? Math.floor(settings.reserveTokens)
+        : DEFAULT_COMPACTION_SETTINGS.reserveTokens;
+    const configuredKeepRecent = Number.isFinite(settings.keepRecentTokens) && settings.keepRecentTokens > 0
+        ? Math.floor(settings.keepRecentTokens)
+        : DEFAULT_COMPACTION_SETTINGS.keepRecentTokens;
+    const reserveCeiling = Math.max(1, Math.floor(windowTokens / 4));
+    const reserveTokens = Math.max(1, Math.min(configuredReserve, reserveCeiling));
+    const keepRecentCeiling = Math.max(1, windowTokens - 2 * reserveTokens);
+    const keepRecentTokens = Math.max(1, Math.min(configuredKeepRecent, keepRecentCeiling));
+    if (reserveTokens === settings.reserveTokens && keepRecentTokens === settings.keepRecentTokens) {
+        return settings;
+    }
+    return { ...settings, reserveTokens, keepRecentTokens };
+}`,
+			"default compaction settings",
+		);
+		patched = replaceRequired(
+			patched,
+			`export function shouldCompact(contextTokens, contextWindow, settings) {
+    if (!settings.enabled)
+        return false;
+    return contextTokens > contextWindow - settings.reserveTokens;
+}`,
+			`export function shouldCompact(contextTokens, contextWindow, settings) {
+    if (!settings.enabled)
+        return false;
+    const effectiveSettings = getEffectiveCompactionSettings(settings, contextWindow);
+    return contextTokens > contextWindow - effectiveSettings.reserveTokens;
+}`,
+			"automatic compaction threshold",
+		);
+		patched = replaceRequired(
+			patched,
+			"export function prepareCompaction(pathEntries, settings) {",
+			`export function prepareCompaction(pathEntries, settings, contextWindow) {
+    const effectiveSettings = getEffectiveCompactionSettings(settings, contextWindow);`,
+			"compaction preparation signature",
+		);
+		patched = replaceRequired(
+			patched,
+			"const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens);",
+			"const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, effectiveSettings.keepRecentTokens);",
+			"compaction keep-recent budget",
+		);
+		patched = replaceRequired(
+			patched,
+			"        settings,\n    };",
+			"        settings: effectiveSettings,\n    };",
+			"compaction preparation settings",
+		);
+	}
+	if (isFullCompactionSource(patched) && !patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryIntegrity)) {
+		patched = replaceRequired(
+			patched,
+			"\nfunction createSummarizationOptions(",
+			`
+// ${PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryIntegrity}
+const CHECKPOINT_REQUIRED_SECTIONS = Object.freeze(["Goal", "Progress", "Next Steps"]);
+const TURN_PREFIX_REQUIRED_SECTIONS = Object.freeze(["Original Request", "Early Progress", "Context for Suffix"]);
+const FILE_OPERATION_BLOCK = /<(?:read-files|modified-files)>[\\s\\S]*?<\\/(?:read-files|modified-files)>/gi;
+function summarySections(summary) {
+    const sections = new Map();
+    let current;
+    for (const line of summary.split(/\\r?\\n/)) {
+        const heading = /^##\\s+(.+?)\\s*$/.exec(line);
+        if (heading) {
+            current = heading[1].trim().toLowerCase();
+            if (!sections.has(current))
+                sections.set(current, []);
+            continue;
+        }
+        if (current)
+            sections.get(current).push(line);
+    }
+    return sections;
+}
+function isSubstantiveSummarySection(lines) {
+    const normalized = lines
+        .join("\\n")
+        .replace(/^#{3,}\\s+.*$/gm, "")
+        .replace(/^\\s*(?:[-*+]\\s*)?\\[[ xX]\\]\\s*/gm, "")
+        .replace(/^\\s*(?:[-*+]|\\d+[.)])\\s+/gm, "")
+        .replace(/[\`*_>#()[\\]]/g, " ")
+        .replace(/\\s+/g, " ")
+        .trim();
+    if (!normalized || /^(?:none|n\\/?a|not applicable|unknown|no (?:information|context|progress|steps?|request|goal)(?: available| provided| yet)?)[.!]*$/i.test(normalized)) {
+        return false;
+    }
+    return normalized.replace(/[^\\p{L}\\p{N}]+/gu, "").length >= 4;
+}
+function summaryContentCharacters(summary) {
+    return summary.replace(/[^\\p{L}\\p{N}]+/gu, "").length;
+}
+function minimumSummaryContentCharacters(sourceCharacters) {
+    if (!Number.isFinite(sourceCharacters) || sourceCharacters <= 0)
+        return 64;
+    return Math.min(512, Math.max(64, Math.floor(sourceCharacters / 200)));
+}
+export function getSummaryUsabilityFailure(summary, label, requiredSections = CHECKPOINT_REQUIRED_SECTIONS, sourceCharacters) {
+    const checkpoint = summary.replace(FILE_OPERATION_BLOCK, "").trim();
+    if (!checkpoint) {
+        return \`\${label} failed: generated an empty or file-list-only checkpoint\`;
+    }
+    const contentCharacters = summaryContentCharacters(checkpoint);
+    const minimumCharacters = minimumSummaryContentCharacters(sourceCharacters);
+    if (contentCharacters < minimumCharacters) {
+        return \`\${label} failed: generated an implausibly small checkpoint (\${contentCharacters} content characters; minimum \${minimumCharacters})\`;
+    }
+    const sections = summarySections(checkpoint);
+    const missing = requiredSections.filter((heading) => !isSubstantiveSummarySection(sections.get(heading.toLowerCase()) ?? []));
+    if (missing.length > 0) {
+        return \`\${label} failed: generated a structurally unusable checkpoint (missing substantive \${missing.join(", ")})\`;
+    }
+    return undefined;
+}
+
+function createSummarizationOptions(`,
+			"summary integrity helper",
+		);
+		patched = replaceRequired(
+			patched,
+			`    const textContent = contentText(response.content);
+    return { text: textContent, usage: response.usage };`,
+			`    const textContent = contentText(response.content);
+    const usabilityFailure = getSummaryUsabilityFailure(textContent, "Summarization", undefined, conversationText.length + (previousSummary?.length ?? 0));
+    if (usabilityFailure) {
+        throw new Error(usabilityFailure);
+    }
+    return { text: textContent, usage: response.usage };`,
+			"history summary integrity",
+		);
+		patched = replaceRequired(
+			patched,
+			`    return {
+        text: contentText(response.content),
+        usage: response.usage,
+    };`,
+			`    const textContent = contentText(response.content);
+    const usabilityFailure = getSummaryUsabilityFailure(textContent, "Turn prefix summarization", TURN_PREFIX_REQUIRED_SECTIONS, conversationText.length);
+    if (usabilityFailure) {
+        throw new Error(usabilityFailure);
+    }
+    return {
+        text: textContent,
+        usage: response.usage,
+    };`,
+			"turn-prefix summary integrity",
+		);
+	}
+	if (
+		isFullCompactionSource(patched) &&
+		patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryIntegrity) &&
+		!patched.includes("function minimumSummaryContentCharacters(")
+	) {
+		patched = replaceRequired(
+			patched,
+			`export function getSummaryUsabilityFailure(summary, label, requiredSections = CHECKPOINT_REQUIRED_SECTIONS) {
+    const checkpoint = summary.replace(FILE_OPERATION_BLOCK, "").trim();`,
+			`function summaryContentCharacters(summary) {
+    return summary.replace(/[^\\p{L}\\p{N}]+/gu, "").length;
+}
+function minimumSummaryContentCharacters(sourceCharacters) {
+    if (!Number.isFinite(sourceCharacters) || sourceCharacters <= 0)
+        return 64;
+    return Math.min(512, Math.max(64, Math.floor(sourceCharacters / 200)));
+}
+export function getSummaryUsabilityFailure(summary, label, requiredSections = CHECKPOINT_REQUIRED_SECTIONS, sourceCharacters) {
+    const checkpoint = summary.replace(FILE_OPERATION_BLOCK, "").trim();`,
+			"summary-size integrity helper",
+		);
+		patched = replaceRequired(
+			patched,
+			"    const sections = summarySections(checkpoint);",
+			`    const contentCharacters = summaryContentCharacters(checkpoint);
+    const minimumCharacters = minimumSummaryContentCharacters(sourceCharacters);
+    if (contentCharacters < minimumCharacters) {
+        return \`\${label} failed: generated an implausibly small checkpoint (\${contentCharacters} content characters; minimum \${minimumCharacters})\`;
+    }
+    const sections = summarySections(checkpoint);`,
+			"summary-size integrity guard",
+		);
+		patched = replaceRequired(
+			patched,
+			'getSummaryUsabilityFailure(textContent, "Summarization")',
+			'getSummaryUsabilityFailure(textContent, "Summarization", undefined, conversationText.length + (previousSummary?.length ?? 0))',
+			"history summary-size integrity",
+		);
+		patched = replaceRequired(
+			patched,
+			'getSummaryUsabilityFailure(textContent, "Turn prefix summarization", TURN_PREFIX_REQUIRED_SECTIONS)',
+			'getSummaryUsabilityFailure(textContent, "Turn prefix summarization", TURN_PREFIX_REQUIRED_SECTIONS, conversationText.length)',
+			"turn-prefix summary-size integrity",
+		);
+	}
+	if (
+		isFullCompactionSource(patched) &&
+		patched.includes(
+			'getSummaryUsabilityFailure(textContent, "Summarization", undefined, conversationText.length)',
+		)
+	) {
+		patched = replaceRequired(
+			patched,
+			'getSummaryUsabilityFailure(textContent, "Summarization", undefined, conversationText.length)',
+			'getSummaryUsabilityFailure(textContent, "Summarization", undefined, conversationText.length + (previousSummary?.length ?? 0))',
+			"incremental summary-size integrity",
+		);
+	}
 	patched = stripStaleSourceMapDirective(
 		patched,
 		"compaction.js.map",
@@ -221,21 +539,21 @@ function patchBranchSummarizationSource(source) {
 	if (!patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.branchResponse)) {
 		patched = replaceRequired(
 			patched,
-		[
-			'        return { error: response.errorMessage || "Summarization failed" };',
-			"    }",
-			"    let summary = contentText(response.content);",
-		].join("\n"),
-		[
-			'        return { error: response.errorMessage || "Summarization failed" };',
-			"    }",
-			`    // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.branchResponse}`,
-			'    if (response.content.some((block) => block.type === "toolCall")) {',
-			'        return { error: "Branch summarization attempted to call a tool" };',
-			"    }",
-			"    let summary = contentText(response.content);",
-		].join("\n"),
-		"branch summary response",
+			[
+				'        return { error: response.errorMessage || "Summarization failed" };',
+				"    }",
+				"    let summary = contentText(response.content);",
+			].join("\n"),
+			[
+				'        return { error: response.errorMessage || "Summarization failed" };',
+				"    }",
+				`    // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.branchResponse}`,
+				'    if (response.content.some((block) => block.type === "toolCall")) {',
+				'        return { error: "Branch summarization attempted to call a tool" };',
+				"    }",
+				"    let summary = contentText(response.content);",
+			].join("\n"),
+			"branch summary response",
 		);
 	}
 	if (!patched.includes("getSummarizationFailure")) {
@@ -257,12 +575,71 @@ function patchBranchSummarizationSource(source) {
 			"branch summary failure",
 		);
 	}
+	if (isFullBranchSource(patched) && !patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.contextBudgets)) {
+		patched = replaceRequired(
+			patched,
+			'import { completeSummarization, estimateTokens, getSummarizationFailure } from "./compaction.js";',
+			'import { completeSummarization, estimateTokens, getEffectiveCompactionSettings, getSummarizationFailure, getSummaryUsabilityFailure } from "./compaction.js";',
+			"branch compaction helper import",
+		);
+		patched = replaceRequired(
+			patched,
+			`    const contextWindow = model.contextWindow || 128000;
+    const tokenBudget = contextWindow - reserveTokens;`,
+			`    const contextWindow = model.contextWindow || 128000;
+    // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.contextBudgets}
+    const effectiveSettings = getEffectiveCompactionSettings({ enabled: true, reserveTokens, keepRecentTokens: 1 }, contextWindow);
+    const tokenBudget = contextWindow - effectiveSettings.reserveTokens;`,
+			"branch summarization token budget",
+		);
+	}
+	if (isFullBranchSource(patched) && !patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.branchIntegrity)) {
+		patched = replaceRequired(
+			patched,
+			"    let summary = contentText(response.content);",
+			`    let summary = contentText(response.content);
+    // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.branchIntegrity}
+    const usabilityFailure = getSummaryUsabilityFailure(summary, "Branch summarization", replaceInstructions && customInstructions ? [] : undefined, conversationText.length);
+    if (usabilityFailure) {
+        return { error: usabilityFailure };
+    }`,
+			"branch summary integrity",
+		);
+	}
+	if (
+		isFullBranchSource(patched) &&
+		patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.branchIntegrity) &&
+		!patched.includes("replaceInstructions && customInstructions ? [] : undefined")
+	) {
+		patched = replaceRequired(
+			patched,
+			'getSummaryUsabilityFailure(summary, "Branch summarization")',
+			'getSummaryUsabilityFailure(summary, "Branch summarization", replaceInstructions && customInstructions ? [] : undefined, conversationText.length)',
+			"branch replacement-prompt summary integrity",
+		);
+	}
 	patched = stripStaleSourceMapDirective(
 		patched,
 		"branch-summarization.js.map",
 		"branch summarization JavaScript source map",
 	);
 	assertPiCompactionToolsPatchedSource("dist/core/compaction/branch-summarization.js", patched);
+	return patched;
+}
+
+function patchAgentSessionSource(source) {
+	let patched = source;
+	if (!patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.contextCallers)) {
+		patched = replaceRequiredOccurrences(
+			patched,
+			"            const preparation = prepareCompaction(pathEntries, settings);",
+			`            // ${PI_COMPACTION_TOOLS_PATCH_MARKERS.contextCallers}
+            const preparation = prepareCompaction(pathEntries, settings, requestModel.contextWindow);`,
+			"agent-session compaction preparation",
+			2,
+		);
+	}
+	assertPiCompactionToolsPatchedSource("dist/core/agent-session.js", patched);
 	return patched;
 }
 
@@ -276,6 +653,44 @@ function patchCompactionTypesSource(source) {
 export declare function getSummarizationFailure(response: AssistantMessage, label: string): string | undefined;
 export declare function completeSummarization(`,
 			"compaction declarations",
+		);
+	}
+	if (isFullCompactionTypesSource(patched) && !patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.contextBudgetTypes)) {
+		patched = replaceRequired(
+			patched,
+			"export declare const DEFAULT_COMPACTION_SETTINGS: CompactionSettings;",
+			`export declare const DEFAULT_COMPACTION_SETTINGS: CompactionSettings;
+/** ${PI_COMPACTION_TOOLS_PATCH_MARKERS.contextBudgetTypes} */
+export declare function getEffectiveCompactionSettings(settings: CompactionSettings, contextWindow: number | undefined): CompactionSettings;`,
+			"compaction budget declarations",
+		);
+		patched = replaceRequired(
+			patched,
+			"export declare function prepareCompaction(pathEntries: SessionEntry[], settings: CompactionSettings): CompactionPreparation | undefined;",
+			"export declare function prepareCompaction(pathEntries: SessionEntry[], settings: CompactionSettings, contextWindow?: number): CompactionPreparation | undefined;",
+			"compaction preparation declaration",
+		);
+	}
+	if (isFullCompactionTypesSource(patched) && !patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryIntegrityTypes)) {
+		patched = replaceRequired(
+			patched,
+			"export declare function completeSummarization(",
+			`/** ${PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryIntegrityTypes} */
+export declare function getSummaryUsabilityFailure(summary: string, label: string, requiredSections?: readonly string[], sourceCharacters?: number): string | undefined;
+export declare function completeSummarization(`,
+			"summary integrity declaration",
+		);
+	}
+	if (
+		isFullCompactionTypesSource(patched) &&
+		patched.includes(PI_COMPACTION_TOOLS_PATCH_MARKERS.summaryIntegrityTypes) &&
+		!patched.includes("sourceCharacters?: number")
+	) {
+		patched = replaceRequired(
+			patched,
+			"export declare function getSummaryUsabilityFailure(summary: string, label: string, requiredSections?: readonly string[]): string | undefined;",
+			"export declare function getSummaryUsabilityFailure(summary: string, label: string, requiredSections?: readonly string[], sourceCharacters?: number): string | undefined;",
+			"summary-size integrity declaration",
 		);
 	}
 	patched = stripStaleSourceMapDirective(
@@ -293,6 +708,8 @@ export function patchPiCompactionToolsSource(relativePath, source) {
 			return patchCompactionSource(source);
 		case "dist/core/compaction/branch-summarization.js":
 			return patchBranchSummarizationSource(source);
+		case "dist/core/agent-session.js":
+			return patchAgentSessionSource(source);
 		case "dist/core/compaction/compaction.d.ts":
 			return patchCompactionTypesSource(source);
 		default:

--- a/scripts/lib/pi-compaction-tools-verifier.mjs
+++ b/scripts/lib/pi-compaction-tools-verifier.mjs
@@ -177,11 +177,21 @@ export async function verifyPiCompactionToolsBehavior(packageRoot) {
 		contextWindow: 128000,
 		maxTokens: 4096,
 	};
+	const checkpointSummary = [
+		"## Goal",
+		"Verify a research claim against its cited source.",
+		"",
+		"## Progress",
+		"- Located and checked the primary paper.",
+		"",
+		"## Next Steps",
+		"1. Reproduce the reported result.",
+	].join("\n");
 	let observedOptions;
 	const textStream = async (_model, _context, options) => {
 		observedOptions = options;
 		return {
-			result: async () => assistantMessage(model, [{ type: "text", text: "summary" }]),
+			result: async () => assistantMessage(model, [{ type: "text", text: checkpointSummary }]),
 		};
 	};
 	await compaction.completeSummarization(
@@ -191,6 +201,56 @@ export async function verifyPiCompactionToolsBehavior(packageRoot) {
 		textStream,
 	);
 	assert.equal(observedOptions?.toolChoice, "none");
+	assert.deepEqual(
+		compaction.getEffectiveCompactionSettings(compaction.DEFAULT_COMPACTION_SETTINGS, 8192),
+		{ enabled: true, reserveTokens: 2048, keepRecentTokens: 4096 },
+	);
+	assert.equal(
+		compaction.shouldCompact(0, 8192, compaction.DEFAULT_COMPACTION_SETTINGS),
+		false,
+	);
+	assert.equal(
+		compaction.shouldCompact(6145, 8192, compaction.DEFAULT_COMPACTION_SETTINGS),
+		true,
+	);
+	assert.deepEqual(
+		compaction.getEffectiveCompactionSettings(compaction.DEFAULT_COMPACTION_SETTINGS, 128000),
+		compaction.DEFAULT_COMPACTION_SETTINGS,
+	);
+	const tinyStructuredStub = [
+		"## Goal",
+		"Research",
+		"## Progress",
+		"Started",
+		"## Next Steps",
+		"Continue",
+	].join("\n");
+	assert.match(
+		compaction.getSummaryUsabilityFailure(
+			tinyStructuredStub,
+			"Summarization",
+			undefined,
+			100_000,
+		) ?? "",
+		/implausibly small checkpoint/,
+	);
+	const mediumStructuredStub = [
+		"## Goal",
+		"A".repeat(60),
+		"## Progress",
+		"B".repeat(60),
+		"## Next Steps",
+		"C".repeat(60),
+	].join("\n");
+	assert.match(
+		compaction.getSummaryUsabilityFailure(
+			mediumStructuredStub,
+			"Summarization",
+			undefined,
+			100_000,
+		) ?? "",
+		/implausibly small checkpoint/,
+	);
 
 	const toolStream = async () => ({
 		result: async () => assistantMessage(
@@ -301,4 +361,48 @@ export async function verifyPiCompactionToolsBehavior(packageRoot) {
 		{ model, apiKey: "test", streamFn: lengthStream },
 	);
 	assert.match(truncatedBranch.error ?? "", /generation hit the token cap/);
+
+	const emptyStream = async () => ({
+		result: async () => assistantMessage(model, [{ type: "text", text: "" }]),
+	});
+	await assert.rejects(
+		() => compaction.generateSummaryWithUsage(
+			[{ role: "user", content: "preserve this research history", timestamp: 1 }],
+			model,
+			2048,
+			"test",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"off",
+			emptyStream,
+		),
+		/empty or file-list-only checkpoint/,
+	);
+	const emptyBranch = await branch.generateBranchSummary(
+		[{
+			type: "message",
+			id: "entry-1",
+			parentId: null,
+			timestamp: new Date(1).toISOString(),
+			message: { role: "user", content: "abandoned research work", timestamp: 1 },
+		}],
+		{ model, apiKey: "test", streamFn: emptyStream },
+	);
+	assert.match(emptyBranch.error ?? "", /empty or file-list-only checkpoint/);
+
+	const accepted = await compaction.generateSummaryWithUsage(
+		[{ role: "user", content: "preserve this research history", timestamp: 1 }],
+		model,
+		2048,
+		"test",
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		"off",
+		textStream,
+	);
+	assert.equal(accepted.text, checkpointSummary);
 }

--- a/scripts/lib/pi-openai-reasoning-patch.mjs
+++ b/scripts/lib/pi-openai-reasoning-patch.mjs
@@ -100,7 +100,16 @@ function isOpenAICompletionsReasoningField(field) {
     return OPENAI_COMPLETIONS_REASONING_FIELDS.includes(field);
 }`;
 
-const OPENAI_REASONING_STREAM_CAPTURE = `                    const reasoningDetails = choice.delta.reasoning_details;
+const OPENAI_REASONING_STREAM_STATE = `        const openAiReasoningDetailsByBlock = new WeakMap();
+        const finalizeOpenAiReasoningDetails = (block) => {
+            const preservedDetails = openAiReasoningDetailsByBlock.get(block);
+            if (!preservedDetails || preservedDetails.length === 0)
+                return;
+            block.thinkingSignature = JSON.stringify(preservedDetails);
+            openAiReasoningDetailsByBlock.delete(block);
+        };`;
+
+const OPENAI_REASONING_QUADRATIC_STREAM_CAPTURE = `                    const reasoningDetails = choice.delta.reasoning_details;
                     if (Array.isArray(reasoningDetails)) {
                         for (const detail of reasoningDetails) {
                             if (!isOpenAIReasoningDetail(detail))
@@ -114,6 +123,32 @@ const OPENAI_REASONING_STREAM_CAPTURE = `                    const reasoningDeta
                             block.thinkingSignature = JSON.stringify(preservedDetails);
                         }
                     }`;
+
+const OPENAI_REASONING_STREAM_CAPTURE = `                    const reasoningDetails = choice.delta.reasoning_details;
+                    if (Array.isArray(reasoningDetails)) {
+                        for (const detail of reasoningDetails) {
+                            if (!isOpenAIReasoningDetail(detail))
+                                continue;
+                            const block = ensureThinkingBlock("");
+                            let preservedDetails = openAiReasoningDetailsByBlock.get(block);
+                            if (!preservedDetails) {
+                                preservedDetails = [];
+                                openAiReasoningDetailsByBlock.set(block, preservedDetails);
+                            }
+                            // Accumulate provider replay data in memory. OpenRouter streams
+                            // reasoning_details as deltas: consecutive text/summary deltas are merged into
+                            // logical entries, while encrypted entries remain opaque and discrete.
+                            appendOpenAIReasoningDetail(preservedDetails, detail);
+                        }
+                    }`;
+
+const OPENAI_REASONING_FINISH_BOUNDARY = `                else if (block.type === "thinking") {
+                    finalizeOpenAiReasoningDetails(block);
+                    stream.push({`;
+
+const OPENAI_REASONING_ERROR_BOUNDARY = `            for (const block of output.content) {
+                finalizeOpenAiReasoningDetails(block);
+                delete block.index;`;
 
 const OPENAI_REASONING_REPLAY_SETUP = `            const thinkingBlocks = msg.content.filter(isThinkingContentBlock);
             const toolCalls = msg.content.filter(isToolCallBlock);
@@ -153,7 +188,13 @@ const OPENAI_REASONING_REPLAY_ASSIGNMENT = `            if (preservedReasoningDe
             }`;
 
 export function isPiOpenAiStructuredReasoningPatched(source) {
-	return source.includes(OPENAI_REASONING_DETAIL_HELPERS);
+	return [
+		OPENAI_REASONING_DETAIL_HELPERS,
+		OPENAI_REASONING_STREAM_STATE,
+		OPENAI_REASONING_STREAM_CAPTURE,
+		OPENAI_REASONING_FINISH_BOUNDARY,
+		OPENAI_REASONING_ERROR_BOUNDARY,
+	].every((fragment) => source.includes(fragment));
 }
 
 export function assertPiOpenAiStructuredReasoningSource(
@@ -162,7 +203,10 @@ export function assertPiOpenAiStructuredReasoningSource(
 ) {
 	for (const fragment of [
 		OPENAI_REASONING_DETAIL_HELPERS,
+		OPENAI_REASONING_STREAM_STATE,
 		OPENAI_REASONING_STREAM_CAPTURE,
+		OPENAI_REASONING_FINISH_BOUNDARY,
+		OPENAI_REASONING_ERROR_BOUNDARY,
 		OPENAI_REASONING_REPLAY_SETUP,
 		OPENAI_REASONING_RAW_REPLAY,
 		OPENAI_REASONING_REPLAY_ASSIGNMENT,
@@ -180,6 +224,7 @@ export function assertPiOpenAiStructuredReasoningSource(
 		"pendingReasoningDetailsByToolCallId",
 		"appendFeynmanEncryptedReasoningDetail",
 		"function isEncryptedReasoningDetail(",
+		"const preservedDetails = parseOpenAIReasoningDetails(block.thinkingSignature) ?? [];",
 	]) {
 		if (source.includes(forbidden)) {
 			throw new Error(`Incomplete Pi AI forward patch ${relativePath}: retained ${forbidden}`);
@@ -187,9 +232,47 @@ export function assertPiOpenAiStructuredReasoningSource(
 	}
 }
 
+function patchPiOpenAiStructuredReasoningAccumulator(source) {
+	let patched = replaceRequired(
+		source,
+		`            timestamp: Date.now(),
+        };
+        try {`,
+		`            timestamp: Date.now(),
+        };
+${OPENAI_REASONING_STREAM_STATE}
+        try {`,
+		"OpenAI structured reasoning stream accumulator",
+	);
+	patched = replaceRequired(
+		patched,
+		OPENAI_REASONING_QUADRATIC_STREAM_CAPTURE,
+		OPENAI_REASONING_STREAM_CAPTURE,
+		"OpenAI structured reasoning constant-work stream capture",
+	);
+	patched = replaceRequired(
+		patched,
+		`                else if (block.type === "thinking") {
+                    stream.push({`,
+		OPENAI_REASONING_FINISH_BOUNDARY,
+		"OpenAI structured reasoning block-finalization boundary",
+	);
+	patched = replaceRequired(
+		patched,
+		`            for (const block of output.content) {
+                delete block.index;`,
+		OPENAI_REASONING_ERROR_BOUNDARY,
+		"OpenAI structured reasoning error-finalization boundary",
+	);
+	return patched;
+}
+
 export function patchPiOpenAiStructuredReasoningSource(source) {
-	if (source.includes(OPENAI_REASONING_DETAIL_HELPERS)) {
+	if (isPiOpenAiStructuredReasoningPatched(source)) {
 		return source;
+	}
+	if (source.includes(OPENAI_REASONING_DETAIL_HELPERS)) {
+		return patchPiOpenAiStructuredReasoningAccumulator(source);
 	}
 
 	let patched = replaceRequired(
@@ -318,7 +401,7 @@ export function patchPiOpenAiStructuredReasoningSource(source) {
                             }
                         }
                     }`,
-		OPENAI_REASONING_STREAM_CAPTURE,
+		OPENAI_REASONING_QUADRATIC_STREAM_CAPTURE,
 		"OpenAI structured reasoning stream capture",
 	);
 	patched = replaceRequired(
@@ -395,6 +478,5 @@ export function patchPiOpenAiStructuredReasoningSource(source) {
                 assistantMsg.reasoning_content === undefined) {`,
 		"OpenAI structured reasoning replay assignment",
 	);
-	return patched;
+	return patchPiOpenAiStructuredReasoningAccumulator(patched);
 }
-

--- a/scripts/lib/pi-openai-responses-no-tools-patch.mjs
+++ b/scripts/lib/pi-openai-responses-no-tools-patch.mjs
@@ -1,0 +1,50 @@
+export const PI_OPENAI_RESPONSES_NO_TOOLS_MARKER =
+	"Feynman Pi 0.84.2 forward patch: Responses omits tool_choice without tools #8649";
+
+const ORIGINAL_TOOL_CHOICE = `    if (options?.toolChoice !== undefined) {
+        params.tool_choice = options.toolChoice;
+    }`;
+
+const PATCHED_TOOL_CHOICE = `    // ${PI_OPENAI_RESPONSES_NO_TOOLS_MARKER}
+    if (options?.toolChoice !== undefined && toolPlacement.immediate.length > 0) {
+        params.tool_choice = options.toolChoice;
+    }`;
+
+function countOccurrences(source, fragment) {
+	return source.split(fragment).length - 1;
+}
+
+export function assertPiOpenAiResponsesNoToolsSource(source, relativePath) {
+	for (const fragment of [
+		PI_OPENAI_RESPONSES_NO_TOOLS_MARKER,
+		"if (options?.toolChoice !== undefined && toolPlacement.immediate.length > 0)",
+	]) {
+		const count = countOccurrences(source, fragment);
+		if (count !== 1) {
+			throw new Error(
+				`Incomplete Pi AI forward patch ${relativePath}: expected exactly one semantic fragment, found ${count}: ${fragment}`,
+			);
+		}
+	}
+	if (source.includes(ORIGINAL_TOOL_CHOICE)) {
+		throw new Error(
+			`Incomplete Pi AI forward patch ${relativePath}: retained no-tools tool_choice`,
+		);
+	}
+}
+
+export function patchPiOpenAiResponsesNoToolsSource(source, relativePath) {
+	if (source.includes(PI_OPENAI_RESPONSES_NO_TOOLS_MARKER)) {
+		assertPiOpenAiResponsesNoToolsSource(source, relativePath);
+		return source;
+	}
+	const count = countOccurrences(source, ORIGINAL_TOOL_CHOICE);
+	if (count !== 1) {
+		throw new Error(
+			`Unsupported Pi 0.84.2 OpenAI Responses no-tools tool choice layout in ${relativePath}; expected 1 occurrence, found ${count}`,
+		);
+	}
+	const patched = source.replace(ORIGINAL_TOOL_CHOICE, PATCHED_TOOL_CHOICE);
+	assertPiOpenAiResponsesNoToolsSource(patched, relativePath);
+	return patched;
+}

--- a/scripts/lib/runtime-workspace-integrity.mjs
+++ b/scripts/lib/runtime-workspace-integrity.mjs
@@ -20,6 +20,7 @@ export const RUNTIME_INPUT_FILES = Object.freeze([
 	"scripts/lib/pi-agent-core-patch.mjs",
 	"scripts/lib/pi-ai-forward-fixes-patch.mjs",
 	"scripts/lib/pi-openai-reasoning-patch.mjs",
+	"scripts/lib/pi-openai-responses-no-tools-patch.mjs",
 	"scripts/lib/pi-cli-args-patch.mjs",
 	"scripts/lib/pi-compaction-tools-patch.mjs",
 	"scripts/lib/pi-edit-line-endings-patch.mjs",

--- a/scripts/prepare-runtime-workspace.mjs
+++ b/scripts/prepare-runtime-workspace.mjs
@@ -123,7 +123,7 @@ const RUNTIME_PACKAGE_OVERRIDES = {
 	"@opentelemetry/sdk-node": "0.221.0",
 	"@opentelemetry/sdk-trace-base": "2.10.0",
 	"@opentelemetry/sdk-trace-node": "2.10.0",
-	"@llamaindex/liteparse": "2.13.1",
+	"@llamaindex/liteparse": "2.14.0",
 	"brace-expansion": "5.0.9",
 	"ip-address": "10.5.0",
 	undici: "8.10.0",

--- a/scripts/verify-installed-docparser.mjs
+++ b/scripts/verify-installed-docparser.mjs
@@ -10,6 +10,17 @@ export const VERIFICATION_PHRASE = "Feynman installed docparser verification phr
 export const HIDDEN_GPO_STAMP = "jbell on PROD1PC69 with BILLS";
 export const HIDDEN_GPO_PRINT_STAMP =
 	"VerDate Aug 31 2005 05:35 Dec 11, 2008 Jkt 079200 PO 00000 Frm 00002 Fmt 6652 Sfmt 6301 E:\\BILLS\\H7337.IH H7337";
+const EXPECTED_PI_DOCPARSER_VERSION = "4.0.0";
+const EXPECTED_LITEPARSE_VERSION = "2.14.0";
+const EXPECTED_LITEPARSE_NATIVE_PACKAGES = [
+	"@llamaindex/liteparse-darwin-arm64",
+	"@llamaindex/liteparse-darwin-x64",
+	"@llamaindex/liteparse-linux-arm64-gnu",
+	"@llamaindex/liteparse-linux-x64-gnu",
+	"@llamaindex/liteparse-linux-x64-musl",
+	"@llamaindex/liteparse-win32-arm64-msvc",
+	"@llamaindex/liteparse-win32-x64-msvc",
+];
 
 const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
 const defaultPackageRoot = resolve(import.meta.dirname, "..");
@@ -143,6 +154,26 @@ export function resolveInstalledDocparserPaths(packageRoot = defaultPackageRoot)
 	const runtimeRequire = createRequire(resolve(runtimeRoot, "package.json"));
 	const liteparseManifestPath = realpathSync(runtimeRequire.resolve("@llamaindex/liteparse/package.json"));
 	const liteparseManifest = JSON.parse(readFileSync(liteparseManifestPath, "utf8"));
+	assert.equal(
+		liteparseManifest.version,
+		EXPECTED_LITEPARSE_VERSION,
+		`Installed LiteParse is not ${EXPECTED_LITEPARSE_VERSION}`,
+	);
+	const liteparseNativePackages = Object.keys(liteparseManifest.optionalDependencies ?? {})
+		.filter((packageName) => packageName.startsWith("@llamaindex/liteparse-"))
+		.sort();
+	assert.deepEqual(
+		liteparseNativePackages,
+		EXPECTED_LITEPARSE_NATIVE_PACKAGES.toSorted(),
+		"Installed LiteParse does not declare the reviewed seven native packages",
+	);
+	for (const packageName of EXPECTED_LITEPARSE_NATIVE_PACKAGES) {
+		assert.equal(
+			liteparseManifest.optionalDependencies?.[packageName],
+			EXPECTED_LITEPARSE_VERSION,
+			`Installed LiteParse does not pin ${packageName} ${EXPECTED_LITEPARSE_VERSION}`,
+		);
+	}
 	const liteparseEntryPath = realpathSync(
 		resolve(liteparseManifestPath, "..", liteparseManifest.main),
 	);
@@ -152,6 +183,14 @@ export function resolveInstalledDocparserPaths(packageRoot = defaultPackageRoot)
 	);
 	const extensionPath = resolve(docparserRoot, "extensions", "docparser", "index.ts");
 	assert.ok(existsSync(extensionPath), `Installed pi-docparser extension is missing: ${extensionPath}`);
+	const docparserManifest = JSON.parse(
+		readFileSync(resolve(docparserRoot, "package.json"), "utf8"),
+	);
+	assert.equal(
+		docparserManifest.version,
+		EXPECTED_PI_DOCPARSER_VERSION,
+		`Installed pi-docparser is not ${EXPECTED_PI_DOCPARSER_VERSION}`,
+	);
 	return {
 		packageRoot: resolvedPackageRoot,
 		piRoot,
@@ -556,10 +595,8 @@ export async function verifyInstalledDocparser(options = {}) {
 
 		const jitiManifest = JSON.parse(readFileSync(paths.jitiManifestPath, "utf8"));
 		verification = {
-			docparser: JSON.parse(
-				readFileSync(resolve(paths.docparserRoot, "package.json"), "utf8"),
-			).version,
-			liteparse: JSON.parse(readFileSync(paths.liteparseManifestPath, "utf8")).version,
+			docparser: EXPECTED_PI_DOCPARSER_VERSION,
+			liteparse: EXPECTED_LITEPARSE_VERSION,
 			jiti: jitiManifest.version,
 			pageCount: parseResult.details.pageCount,
 			hits: searchResult.details.hits.length,

--- a/scripts/verify-package-artifact.mjs
+++ b/scripts/verify-package-artifact.mjs
@@ -6,6 +6,14 @@ import {
 	FEYNMAN_UNDICI_VERSION,
 } from "./lib/pi-undici-proxy-patch.mjs";
 import {
+	FEYNMAN_LITEPARSE_GIT_HEAD,
+	FEYNMAN_LITEPARSE_NATIVE_PACKAGES,
+	FEYNMAN_LITEPARSE_VERSION,
+	verifyLiteparseManifestContract,
+	verifyLiteparseRootLockContract,
+	verifyLiteparseRuntimeLockContract,
+} from "./lib/liteparse-release-contract.mjs";
+import {
 	assertPiAiForwardFixArchive,
 	assertPiAiForwardFixPackageTree,
 } from "./lib/pi-ai-forward-fixes-verifier.mjs";
@@ -41,17 +49,7 @@ const prunedNative = process.argv.includes("--pruned-native");
 const packageRequire = createRequire(resolve(packageRoot, "package.json"));
 const FEYNMAN_BRACE_EXPANSION_VERSION = "5.0.9";
 const FEYNMAN_IP_ADDRESS_VERSION = "10.5.0";
-const FEYNMAN_LITEPARSE_VERSION = "2.13.1";
-const FEYNMAN_LITEPARSE_INTEGRITY = "sha512-EtMFEYFZIY+Gpj6nebvyiIkU9NTmLG5CXe2WpYy5S0pjCLfFgW0Tn9iN68ik3QIk64ELSdLJlgijSzCzfSpeoQ==";
-const FEYNMAN_LITEPARSE_NATIVE_PACKAGES = [
-	"@llamaindex/liteparse-darwin-arm64",
-	"@llamaindex/liteparse-darwin-x64",
-	"@llamaindex/liteparse-linux-arm64-gnu",
-	"@llamaindex/liteparse-linux-x64-gnu",
-	"@llamaindex/liteparse-linux-x64-musl",
-	"@llamaindex/liteparse-win32-arm64-msvc",
-	"@llamaindex/liteparse-win32-x64-msvc",
-];
+const FEYNMAN_PI_DOCPARSER_VERSION = "4.0.0";
 const PI_INTERACTIVE_UPDATE_NOTICE_MARKER = "// Feynman: package update notices use the full update command.";
 const PI_INTERACTIVE_UPDATE_NOTICE_ACTION = 'const action = theme.fg("accent", `${APP_NAME} update`);';
 const PI_INTERACTIVE_UPDATE_NOTICE_OLD_ANCHOR = `showPackageUpdateNotification(packages) {
@@ -146,6 +144,11 @@ for (const packageName of FEYNMAN_LITEPARSE_NATIVE_PACKAGES) {
 	if (manifest.optionalDependencies?.[packageName] !== FEYNMAN_LITEPARSE_VERSION) {
 		fail(`package.json does not request ${packageName} ${FEYNMAN_LITEPARSE_VERSION}`);
 	}
+}
+const rootLockPath = resolve(packageRoot, "package-lock.json");
+if (existsSync(rootLockPath)) {
+	const rootLock = readJson(rootLockPath, "package-lock.json");
+	verifyLiteparseRootLockContract(rootLock, fail);
 }
 
 for (const name of [
@@ -544,8 +547,8 @@ if (expectedPiWebAccessVersion !== "0.24.2") {
 	fail("committed runtime lock does not pin pi-web-access 0.24.2");
 }
 const expectedPiDocparserVersion = runtimeLock.packages?.[""]?.dependencies?.["pi-docparser"];
-if (expectedPiDocparserVersion !== "4.0.0") {
-	fail("committed runtime lock does not pin pi-docparser 4.0.0");
+if (expectedPiDocparserVersion !== FEYNMAN_PI_DOCPARSER_VERSION) {
+	fail(`committed runtime lock does not pin pi-docparser ${FEYNMAN_PI_DOCPARSER_VERSION}`);
 }
 if (
 	runtimeLock.packages?.["node_modules/@hono/node-server"]?.version !== "2.0.12"
@@ -555,15 +558,7 @@ if (
 if (runtimeLock.packages?.["node_modules/ip-address"]?.version !== FEYNMAN_IP_ADDRESS_VERSION) {
 	fail(`committed runtime lock does not resolve ip-address ${FEYNMAN_IP_ADDRESS_VERSION}`);
 }
-const liteparseLockEntry = runtimeLock.packages?.["node_modules/@llamaindex/liteparse"];
-if (
-	liteparseLockEntry?.version !== FEYNMAN_LITEPARSE_VERSION ||
-	liteparseLockEntry?.resolved !==
-		`https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-${FEYNMAN_LITEPARSE_VERSION}.tgz` ||
-	liteparseLockEntry?.integrity !== FEYNMAN_LITEPARSE_INTEGRITY
-) {
-	fail(`committed runtime lock does not resolve exact LiteParse ${FEYNMAN_LITEPARSE_VERSION}`);
-}
+verifyLiteparseRuntimeLockContract(runtimeLock, fail);
 if (runtimeLock.packages?.[""]?.dependencies?.undici !== FEYNMAN_UNDICI_VERSION) {
 	fail(`committed runtime lock does not pin Undici ${FEYNMAN_UNDICI_VERSION}`);
 }
@@ -844,17 +839,7 @@ const liteparseManifest = readArchivedJson(
 	archivePath,
 	"npm/node_modules/@llamaindex/liteparse/package.json",
 );
-if (liteparseManifest.version !== FEYNMAN_LITEPARSE_VERSION) {
-	fail(`runtime LiteParse is not ${FEYNMAN_LITEPARSE_VERSION}`);
-}
-for (const [packageName, version] of Object.entries(liteparseManifest.optionalDependencies ?? {})) {
-	if (
-		packageName.startsWith("@llamaindex/liteparse-") &&
-		version !== FEYNMAN_LITEPARSE_VERSION
-	) {
-		fail(`runtime LiteParse optional package ${packageName} is not ${FEYNMAN_LITEPARSE_VERSION}`);
-	}
-}
+verifyLiteparseManifestContract(liteparseManifest, fail, "runtime");
 requireMarkers(
 	readArchivedText(
 		archivePath,
@@ -1190,6 +1175,7 @@ console.log(JSON.stringify({
 	piVersion: expectedPiVersion,
 	piDocparserVersion: expectedPiDocparserVersion,
 	ipAddressVersion: FEYNMAN_IP_ADDRESS_VERSION,
+	liteparseGitHead: FEYNMAN_LITEPARSE_GIT_HEAD,
 	liteparseVersion: FEYNMAN_LITEPARSE_VERSION,
 	piWebAccessVersion: expectedPiWebAccessVersion,
 	undiciVersion: FEYNMAN_UNDICI_VERSION,

--- a/tests/liteparse-2-14.test.ts
+++ b/tests/liteparse-2-14.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { performance } from "node:perf_hooks";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import {
+	verifyLiteparseRootLockContract,
+	verifyLiteparseRuntimeLockContract,
+} from "../scripts/lib/liteparse-release-contract.mjs";
+
+const require = createRequire(import.meta.url);
+const LITEPARSE_GIT_HEAD = "b75603d44027cc70c44a9d9f9f20458c93fd37a7";
+const LITEPARSE_VERSION = "2.14.0";
+const LITEPARSE_INTEGRITY =
+	"sha512-lIFBbTRs87Bpp45Lm986hUDEPndm85pT9l/BM1dtWhQs0zTLEkpHLrgbOxGG2rjBqDgJM5fdChT8LWUd4ZThWA==";
+const NATIVE_INTEGRITIES: Record<string, string> = {
+	"@llamaindex/liteparse-darwin-arm64":
+		"sha512-waYoHguqomVv43KEEqNf6nWSrpfMnNC8LXRtgN+a7F/WwICfNzrgA5Z8ayj2jhvvpYv7tsJ25M1vl8bb0i5UlA==",
+	"@llamaindex/liteparse-darwin-x64":
+		"sha512-akTk/e6eEHgeP14f+8QiqueiEjiHTutX03XxRizXNn2aoTtQCEfElN4/p0rwTSFq35E76N7/z3ZVP5l1h4G4pw==",
+	"@llamaindex/liteparse-linux-arm64-gnu":
+		"sha512-svIeleEBGQTAgeWaTySUgzba3rsEUGNaDN11B6wGvDjAyI59R/JkhM1+a7TP3T19v8+Ik+F/nzTz/AB6xJxQIA==",
+	"@llamaindex/liteparse-linux-x64-gnu":
+		"sha512-UQTedZ9FJJ59pk4fFxBF6rPOoPssRf9580kCT1IkDowUavcAUMygfn3gtxfMtEOCTHsGpPHXLGmd5ICZOzmRbg==",
+	"@llamaindex/liteparse-linux-x64-musl":
+		"sha512-3Od2QCu68nDzvTE9rSNvMmAq1VkMwY94I/38ZwQqONdqGnBYCTKpBaMR2guxcky8Pn4sKVnILHwUgqb8jnLvTw==",
+	"@llamaindex/liteparse-win32-arm64-msvc":
+		"sha512-TRQh4pPdL2B34ihxYdDsxFgruk+u3opc+Spq6VMr/gwo+ASmEhVTxgnz/2RDEIlleXNYnxMCPI1LVyKiZgGn0w==",
+	"@llamaindex/liteparse-win32-x64-msvc":
+		"sha512-bv7T2/l9S4x2Cf66MlFK647yHyNVfeNmeJt+8YHcuG1KbBLwCO47brQdbetqw3+UJKCr4usEc8rt8+Kl1LvnVA==",
+};
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+function nativeLiteParsePackage() {
+	if (process.platform === "darwin" && process.arch === "arm64") {
+		return "@llamaindex/liteparse-darwin-arm64";
+	}
+	if (process.platform === "darwin" && process.arch === "x64") {
+		return "@llamaindex/liteparse-darwin-x64";
+	}
+	if (process.platform === "linux" && process.arch === "arm64") {
+		return "@llamaindex/liteparse-linux-arm64-gnu";
+	}
+	if (process.platform === "linux" && process.arch === "x64") {
+		const report = process.report?.getReport() as {
+			header?: { glibcVersionRuntime?: string };
+		};
+		return report?.header?.glibcVersionRuntime
+			? "@llamaindex/liteparse-linux-x64-gnu"
+			: "@llamaindex/liteparse-linux-x64-musl";
+	}
+	if (process.platform === "win32" && process.arch === "arm64") {
+		return "@llamaindex/liteparse-win32-arm64-msvc";
+	}
+	if (process.platform === "win32" && process.arch === "x64") {
+		return "@llamaindex/liteparse-win32-x64-msvc";
+	}
+	throw new Error(`Unsupported LiteParse test platform: ${process.platform}-${process.arch}`);
+}
+
+function createTwoPagePdf() {
+	const pageTexts = ["LiteParse 2.14 page one", "LiteParse 2.14 page two"];
+	const objects = [
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>",
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 400] /Resources << /Font << /F1 5 0 R >> >> /Contents 6 0 R >>",
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 500] /Resources << /Font << /F1 5 0 R >> >> /Contents 7 0 R >>",
+		"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+		"",
+		"",
+	];
+	for (let index = 0; index < pageTexts.length; index += 1) {
+		const content = `BT\n/F1 18 Tf\n0 g\n36 320 Td\n(${pageTexts[index]}) Tj\nET\n`;
+		objects[5 + index] = `<< /Length ${Buffer.byteLength(content, "latin1")} >>\nstream\n${content}endstream`;
+	}
+	let source = "%PDF-1.4\n%\u00e2\u00e3\u00cf\u00d3\n";
+	const offsets = [0];
+	for (let index = 0; index < objects.length; index += 1) {
+		offsets.push(Buffer.byteLength(source, "latin1"));
+		source += `${index + 1} 0 obj\n${objects[index]}\nendobj\n`;
+	}
+	const xrefOffset = Buffer.byteLength(source, "latin1");
+	source += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+	for (const offset of offsets.slice(1)) {
+		source += `${String(offset).padStart(10, "0")} 00000 n \n`;
+	}
+	source += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+	return Buffer.from(source, "latin1");
+}
+
+function loadNativeLiteParse() {
+	const packageName = nativeLiteParsePackage();
+	const manifest = require(`${packageName}/package.json`) as { version?: string };
+	assert.equal(manifest.version, LITEPARSE_VERSION, `${packageName} is not ${LITEPARSE_VERSION}`);
+	const nativeModule = require(packageName);
+	const LiteParse = nativeModule.LiteParse ?? nativeModule.default?.LiteParse;
+	assert.equal(typeof LiteParse, "function", `${packageName} has no LiteParse`);
+	return LiteParse;
+}
+
+test("LiteParse 2.14 release identity and all native locks are exact", () => {
+	const manifest = JSON.parse(readFileSync(resolve("package.json"), "utf8")) as {
+		optionalDependencies?: Record<string, string>;
+	};
+	const lock = JSON.parse(readFileSync(resolve("package-lock.json"), "utf8")) as {
+		packages?: Record<
+			string,
+			{
+				integrity?: string;
+				optional?: boolean;
+				optionalDependencies?: Record<string, string>;
+				resolved?: string;
+				version?: string;
+			}
+		>;
+	};
+	for (const [packageName, integrity] of Object.entries(NATIVE_INTEGRITIES)) {
+		assert.equal(manifest.optionalDependencies?.[packageName], LITEPARSE_VERSION);
+		assert.equal(
+			lock.packages?.[""]?.optionalDependencies?.[packageName],
+			LITEPARSE_VERSION,
+		);
+		assert.deepEqual(
+			{
+				version: lock.packages?.[`node_modules/${packageName}`]?.version,
+				resolved: lock.packages?.[`node_modules/${packageName}`]?.resolved,
+				integrity: lock.packages?.[`node_modules/${packageName}`]?.integrity,
+				optional: lock.packages?.[`node_modules/${packageName}`]?.optional,
+			},
+			{
+				version: LITEPARSE_VERSION,
+				resolved: `https://registry.npmjs.org/${packageName}/-/${packageName.slice("@llamaindex/".length)}-${LITEPARSE_VERSION}.tgz`,
+				integrity,
+				optional: true,
+			},
+		);
+	}
+
+	const artifactVerifier = readFileSync(resolve("scripts/verify-package-artifact.mjs"), "utf8");
+	const releaseContract = readFileSync(
+		resolve("scripts/lib/liteparse-release-contract.mjs"),
+		"utf8",
+	);
+	const installedVerifier = readFileSync(
+		resolve("scripts/verify-installed-docparser.mjs"),
+		"utf8",
+	);
+	assert.match(artifactVerifier, /from "\.\/lib\/liteparse-release-contract\.mjs"/);
+	assert.match(releaseContract, new RegExp(LITEPARSE_GIT_HEAD));
+	assert.match(releaseContract, new RegExp(LITEPARSE_INTEGRITY.replaceAll("+", "\\+")));
+	assert.match(installedVerifier, /EXPECTED_PI_DOCPARSER_VERSION = "4\.0\.0"/);
+	assert.match(installedVerifier, /EXPECTED_LITEPARSE_VERSION = "2\.14\.0"/);
+	for (const packageName of Object.keys(NATIVE_INTEGRITIES)) {
+		assert.match(installedVerifier, new RegExp(packageName.replace("/", "\\/")));
+	}
+
+	const fail = (message: string): never => {
+		throw new Error(message);
+	};
+	assert.doesNotThrow(() => verifyLiteparseRootLockContract(lock, fail));
+	const runtimeLock = JSON.parse(
+		readFileSync(resolve(".feynman/runtime-package-lock.json"), "utf8"),
+	);
+	assert.doesNotThrow(() => verifyLiteparseRuntimeLockContract(runtimeLock, fail));
+	const mutatedRuntimeLock = structuredClone(runtimeLock);
+	Object.assign(
+		mutatedRuntimeLock.packages["node_modules/@llamaindex/liteparse-win32-x64-msvc"],
+		{
+			version: "9.9.9",
+			resolved: "https://packages.example.invalid/foreign.tgz",
+			integrity: "sha512-foreign",
+		},
+	);
+	assert.throws(
+		() => verifyLiteparseRuntimeLockContract(mutatedRuntimeLock, fail),
+		/liteparse-win32-x64-msvc@2\.14\.0/,
+	);
+});
+
+test("0.3.44 release notes explain the LiteParse document-research upgrade", () => {
+	for (const path of [
+		resolve("RELEASES.md"),
+		resolve("website/src/content/docs/reference/releases.md"),
+	]) {
+		const releases = readFileSync(path, "utf8");
+		const currentRelease =
+			releases.match(/## v0\.3\.44[\s\S]*?(?=\n## v0\.3\.43)/)?.[0] ?? "";
+		assert.match(currentRelease, /LiteParse runtime to `2\.14\.0`/);
+		assert.match(currentRelease, /OCR rasterization.*bounded worker-sized rounds/i);
+		assert.match(currentRelease, /quadratic work/i);
+	}
+});
+
+test("LiteParse 2.14 parses both pages and renders PNG screenshots", async () => {
+	const LiteParse = loadNativeLiteParse();
+	const pdf = createTwoPagePdf();
+	const parser = new LiteParse({
+		ocrEnabled: false,
+		extractScreenshots: true,
+		dpi: 72,
+		outputFormat: "json",
+		quiet: true,
+	});
+	const result = await parser.parse(pdf);
+	assert.equal(result.totalPages, 2);
+	assert.equal(result.pages.length, 2);
+	assert.match(result.pages[0].text, /LiteParse 2\.14 page one/);
+	assert.match(result.pages[1].text, /LiteParse 2\.14 page two/);
+	assert.equal(result.screenshots.length, 2);
+
+	const screenshots = await parser.screenshot(pdf, [1, 2]);
+	assert.equal(screenshots.length, 2);
+	for (const [index, screenshot] of screenshots.entries()) {
+		assert.equal(screenshot.pageNum, index + 1);
+		assert.ok(screenshot.imageBuffer.byteLength > PNG_SIGNATURE.byteLength);
+		assert.deepEqual(
+			Buffer.from(screenshot.imageBuffer).subarray(0, PNG_SIGNATURE.byteLength),
+			PNG_SIGNATURE,
+		);
+	}
+});
+
+test("LiteParse 2.14 bounds bbox dedup work on a 20k-item ribbon page", { timeout: 20_000 }, () => {
+	const LiteParse = loadNativeLiteParse();
+	const parser = new LiteParse({
+		ocrEnabled: false,
+		outputFormat: "json",
+		quiet: true,
+	});
+	const itemCount = 20_000;
+	const startedAt = performance.now();
+	const result = parser.parsePages([
+		{
+			pageNumber: 1,
+			pageWidth: 400,
+			pageHeight: itemCount * 8 + 20,
+			textItems: Array.from({ length: itemCount }, (_, index) => ({
+				text: `cell-${index % 101}`,
+				x: 10 + (index % 8) * 40,
+				y: 10 + index * 8,
+				width: 30,
+				height: 6,
+				fontName: "Helvetica",
+				fontSize: 5,
+				fontHeight: 5,
+				fontWeight: 400,
+				words: [],
+			})),
+		},
+	]);
+	const elapsedMs = performance.now() - startedAt;
+	assert.equal(result.pages.length, 1);
+	assert.equal(result.pages[0].textItems.length, itemCount);
+	assert.ok(elapsedMs < 15_000, `20k-item bbox stress took ${elapsedMs.toFixed(1)}ms`);
+});

--- a/tests/package-seeding.test.ts
+++ b/tests/package-seeding.test.ts
@@ -81,7 +81,7 @@ test("prepare runtime workspace pins audited transitive runtime overrides", asyn
 	assert.match(runtimeWorkspaceSource, /"@mozilla\/readability": "0\.6\.0"/);
 	assert.match(runtimeWorkspaceSource, /"@opentelemetry\/sdk-node": "0\.221\.0"/);
 	assert.match(runtimeWorkspaceSource, /"@opentelemetry\/resources": "2\.10\.0"/);
-	assert.match(runtimeWorkspaceSource, /"@llamaindex\/liteparse": "2\.13\.1"/);
+	assert.match(runtimeWorkspaceSource, /"@llamaindex\/liteparse": "2\.14\.0"/);
 	assert.match(runtimeWorkspaceSource, /"ip-address": "10\.5\.0"/);
 	assert.match(runtimeWorkspaceSource, /undici: "8\.10\.0"/);
 	assert.match(runtimeWorkspaceSource, /"undici",\n\];/);
@@ -170,9 +170,9 @@ test("release manifests pin current document and website security repairs", () =
 		"@llamaindex/liteparse-win32-arm64-msvc",
 		"@llamaindex/liteparse-win32-x64-msvc",
 	]) {
-		assert.equal(manifest.optionalDependencies?.[packageName], "2.13.1");
-		assert.equal(lock.packages?.[""]?.optionalDependencies?.[packageName], "2.13.1");
-		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.version, "2.13.1");
+		assert.equal(manifest.optionalDependencies?.[packageName], "2.14.0");
+		assert.equal(lock.packages?.[""]?.optionalDependencies?.[packageName], "2.14.0");
+		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.version, "2.14.0");
 		assert.equal(lock.packages?.[`node_modules/${packageName}`]?.optional, true);
 	}
 	assert.equal(websiteManifest.overrides?.["js-yaml"], "4.3.1");

--- a/tests/pi-agent-abort-queue-patch.test.ts
+++ b/tests/pi-agent-abort-queue-patch.test.ts
@@ -1,0 +1,269 @@
+import test, { type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import {
+	cpSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+
+import {
+	assertPiAgentCorePatchSource,
+	patchPiAgentCoreSource,
+} from "../scripts/lib/pi-agent-core-patch.mjs";
+import { RUNTIME_INPUT_FILES } from "../scripts/lib/runtime-workspace-integrity.mjs";
+
+const appRoot = process.cwd();
+const agentCoreRoot = resolve(
+	appRoot,
+	"node_modules",
+	"@earendil-works",
+	"pi-agent-core",
+);
+const agentLoopPath = resolve(agentCoreRoot, "dist", "agent-loop.js");
+const abortGuardMarker =
+	"Feynman Pi 0.84.2 forward patch: preserve queued input on abort #8658";
+
+const emptyUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+test("Pi 0.84.2 abort queue patch is exact, idempotent, drift-closed, and runtime-hashed", () => {
+	const packageJson = JSON.parse(
+		readFileSync(resolve(agentCoreRoot, "package.json"), "utf8"),
+	) as { version?: string };
+	assert.equal(packageJson.version, "0.84.2");
+
+	const patchSource = readFileSync(
+		resolve(appRoot, "scripts", "lib", "pi-agent-core-patch.mjs"),
+		"utf8",
+	);
+	assert.match(
+		patchSource,
+		/const PI_AGENT_CORE_PATCH_REQUIRED_VERSION = "0\.84\.2";/,
+	);
+	const runtimePatchSource = readFileSync(
+		resolve(appRoot, "src", "pi", "runtime-patches.ts"),
+		"utf8",
+	);
+	const runtimeCorrectnessSource = readFileSync(
+		resolve(appRoot, "scripts", "lib", "pi-runtime-correctness-patch.mjs"),
+		"utf8",
+	);
+	assert.match(
+		runtimeCorrectnessSource,
+		/export const PI_RUNTIME_CORRECTNESS_REQUIRED_VERSION = "0\.84\.2";/,
+	);
+	assert.match(
+		runtimePatchSource,
+		/assertPiRuntimeCorrectnessVersion\(bundledPiVersion, "bundled pi-coding-agent"\)/,
+	);
+	assert.ok(
+		RUNTIME_INPUT_FILES.includes("scripts/lib/pi-agent-core-patch.mjs"),
+		"runtime input hash must include the AgentCore patch",
+	);
+
+	const once = patchPiAgentCoreSource(readFileSync(agentLoopPath, "utf8"));
+	const twice = patchPiAgentCoreSource(once);
+	assert.equal(twice, once);
+	assert.match(once, new RegExp(abortGuardMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	assert.match(
+		once,
+		/await emit\(\{ type: "turn_end", message, toolResults \}\);[\s\S]*if \(signal\?\.aborted\) \{[\s\S]*await emit\(\{ type: "agent_end", messages: newMessages \}\);[\s\S]*return;[\s\S]*const nextTurnContext = \{/,
+	);
+	assert.doesNotThrow(() =>
+		assertPiAgentCorePatchSource(once, "patched Pi 0.84.2 AgentCore")
+	);
+
+	const drifted = once.replace(
+		"            if (signal?.aborted) {",
+		"            if (false && signal?.aborted) {",
+	);
+	assert.notEqual(drifted, once);
+	assert.throws(
+		() => patchPiAgentCoreSource(drifted),
+		/missing exact post-turn abort queue guard/,
+	);
+	const renamedLoop = readFileSync(agentLoopPath, "utf8").replace(
+		"async function runLoop(",
+		"async function bypassedRunLoop(",
+	);
+	const renamedLoopPatched = patchPiAgentCoreSource(renamedLoop);
+	assert.match(
+		renamedLoopPatched,
+		new RegExp(abortGuardMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+	);
+});
+
+async function loadPatchedAgentCore(t: TestContext) {
+	const tempRoot = mkdtempSync(join(resolve(appRoot, "node_modules"), ".feynman-pi-abort-"));
+	t.after(() => rmSync(tempRoot, { recursive: true, force: true }));
+	const packageRoot = resolve(tempRoot, "pi-agent-core");
+	cpSync(agentCoreRoot, packageRoot, { recursive: true });
+	const copiedAgentLoopPath = resolve(packageRoot, "dist", "agent-loop.js");
+	writeFileSync(
+		copiedAgentLoopPath,
+		patchPiAgentCoreSource(readFileSync(copiedAgentLoopPath, "utf8")),
+		"utf8",
+	);
+	return import(
+		`${pathToFileURL(resolve(packageRoot, "dist", "index.js")).href}?abort-queue=${Date.now()}`
+	) as Promise<typeof import("@earendil-works/pi-agent-core")>;
+}
+
+for (const queueKind of ["steering", "follow-up"] as const) {
+	test(`tool-time abort preserves queued ${queueKind} input without a second LLM call`, async (t) => {
+		const { runAgentLoop } = await loadPatchedAgentCore(t);
+		const controller = new AbortController();
+		let toolIsRunning = false;
+		let markToolStarted: (() => void) | undefined;
+		const toolStarted = new Promise<void>((resolveStarted) => {
+			markToolStarted = resolveStarted;
+		});
+		let releaseTool: (() => void) | undefined;
+		const queuedMessage = {
+			role: "user" as const,
+			content: `${queueKind} research input`,
+			timestamp: Date.now(),
+		};
+		const queuedMessages = [queuedMessage];
+		let queueReads = 0;
+		const readQueue = async () => {
+			queueReads++;
+			if (!toolIsRunning) return [];
+			return queuedMessages.splice(0);
+		};
+		const slowTool = {
+			name: "slow",
+			label: "Slow",
+			description: "Hold a research turn while input is queued",
+			parameters: Type.Object({}),
+			executionMode: "sequential" as const,
+			async execute(
+				_id: string,
+				_params: unknown,
+				signal?: AbortSignal,
+			) {
+				toolIsRunning = true;
+				markToolStarted?.();
+				await new Promise<void>((resolveTool) => {
+					releaseTool = resolveTool;
+					if (signal?.aborted) {
+						resolveTool();
+						return;
+					}
+					signal?.addEventListener("abort", () => resolveTool(), { once: true });
+				});
+				return {
+					content: [{ type: "text" as const, text: "tool stopped" }],
+					details: {},
+					isError: true,
+				};
+			},
+		};
+		const model = {
+			id: "abort-queue-test",
+			name: "abort-queue-test",
+			api: "openai-completions" as const,
+			provider: "abort-queue-test",
+			baseUrl: "https://provider.example/v1",
+			reasoning: false,
+			input: ["text" as const],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 8192,
+			maxTokens: 1024,
+		};
+		let llmCalls = 0;
+		const streamFn = () => {
+			llmCalls++;
+			const stream = createAssistantMessageEventStream();
+			if (llmCalls === 1) {
+				queueMicrotask(() => {
+					stream.push({
+						type: "done",
+						reason: "toolUse",
+						message: {
+							role: "assistant",
+							content: [{
+								type: "toolCall",
+								id: "slow-1",
+								name: "slow",
+								arguments: {},
+							}],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: emptyUsage,
+							stopReason: "toolUse",
+							timestamp: Date.now(),
+						},
+					});
+				});
+			}
+			return stream;
+		};
+		const events: Array<{ type: string; messages?: unknown[] }> = [];
+		const run = runAgentLoop(
+			[{ role: "user", content: "start", timestamp: Date.now() }],
+			{ systemPrompt: "", messages: [], tools: [slowTool] },
+			{
+				model,
+				convertToLlm: (messages) => messages as never,
+				toolExecution: "sequential",
+				...(queueKind === "steering"
+					? { getSteeringMessages: readQueue }
+					: { getFollowUpMessages: readQueue }),
+			},
+			(event) => {
+				events.push(event as { type: string; messages?: unknown[] });
+			},
+			controller.signal,
+			streamFn,
+		);
+
+		await toolStarted;
+		controller.abort();
+		releaseTool?.();
+		const messages = await run;
+
+		assert.equal(llmCalls, 1);
+		assert.equal(
+			events.filter((event) => event.type === "agent_end").length,
+			1,
+		);
+		assert.equal(
+			events.filter((event) => event.type === "turn_end").length,
+			1,
+		);
+		assert.equal(events.at(-1)?.type, "agent_end");
+		assert.equal(queueReads, queueKind === "steering" ? 1 : 0);
+		assert.deepEqual(queuedMessages, [queuedMessage]);
+		assert.equal(
+			messages.some(
+				(message) =>
+					message.role === "user" &&
+					message.content === queuedMessage.content,
+			),
+			false,
+		);
+		assert.equal(
+			messages.filter(
+				(message) =>
+					message.role === "assistant" &&
+					message.stopReason === "aborted",
+			).length,
+			0,
+		);
+	});
+}

--- a/tests/pi-ai-forward-fixes-patch.test.ts
+++ b/tests/pi-ai-forward-fixes-patch.test.ts
@@ -166,11 +166,11 @@ test("structured reasoning assertions reject no-op and mutated semantics", () =>
 		["text merge", "        lastDetail.text += detail.text;", "        void detail.text;"],
 		["summary merge", "        lastDetail.summary += detail.summary;", "        void detail.summary;"],
 		["encrypted append", "    details.push({ ...detail });", "    void detail;"],
-		[
-			"ordered storage",
-			"                            block.thinkingSignature = JSON.stringify(preservedDetails);",
-			"                            block.thinkingSignature = block.thinkingSignature;",
-		],
+			[
+				"ordered storage",
+				"            block.thinkingSignature = JSON.stringify(preservedDetails);",
+				"            void preservedDetails;",
+			],
 		[
 			"provider identity gate",
 			"            const legacyMessageReasoningDetails = msg.provider === model.provider &&",

--- a/tests/pi-ai-stream-hotfixes.test.ts
+++ b/tests/pi-ai-stream-hotfixes.test.ts
@@ -1,0 +1,449 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { resolve } from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+import {
+	assertPiAiForwardFixSource,
+	PI_AI_FORWARD_FIX_REQUIRED_VERSION,
+	patchPiAiForwardFixSource,
+} from "../scripts/lib/pi-ai-forward-fixes-patch.mjs";
+
+const appRoot = process.cwd();
+const piAiRoot = resolve(appRoot, "node_modules", "@earendil-works", "pi-ai");
+const nestedPiAiRoot = resolve(
+	appRoot,
+	"node_modules",
+	"@earendil-works",
+	"pi-coding-agent",
+	"node_modules",
+	"@earendil-works",
+	"pi-ai",
+);
+
+function readPiAiSource(relativePath: string): string {
+	return readFileSync(resolve(piAiRoot, ...relativePath.split("/")), "utf8");
+}
+
+async function importPatchedPiAiApi(relativePath: string, label: string) {
+	const modulePath = resolve(piAiRoot, ...relativePath.split("/"));
+	const moduleUrl = pathToFileURL(modulePath);
+	const patched = patchPiAiForwardFixSource(relativePath, readFileSync(modulePath, "utf8"));
+	assert.doesNotThrow(() => assertPiAiForwardFixSource(relativePath, patched));
+	const linked = patched.replace(
+		/from "([^"]+)";/g,
+		(_match, specifier: string) => {
+			const resolved = specifier.startsWith(".")
+				? new URL(specifier, moduleUrl).href
+				: import.meta.resolve(specifier);
+			return `from ${JSON.stringify(resolved)};`;
+		},
+	);
+	return import(`data:text/javascript;base64,${Buffer.from(linked).toString("base64")}#${label}-${Date.now()}`);
+}
+
+function openAiCompletionsModel(provider: string, id: string, baseUrl: string) {
+	return {
+		id,
+		name: id,
+		api: "openai-completions" as const,
+		provider,
+		baseUrl,
+		reasoning: true,
+		input: ["text"] as const,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 4096,
+	};
+}
+
+function openAiResponsesModel() {
+	return {
+		id: "grok-4.6-test",
+		name: "grok-4.6-test",
+		api: "openai-responses" as const,
+		provider: "xai",
+		baseUrl: "https://api.x.ai/v1",
+		reasoning: true,
+		input: ["text"] as const,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 500_000,
+		maxTokens: 4096,
+	};
+}
+
+function sseBody(deltas: unknown[], model = "research-model"): string {
+	const events = deltas.map((delta) => `data: ${JSON.stringify({
+		id: "chatcmpl-hotfix",
+		model,
+		choices: [{ index: 0, delta, finish_reason: null }],
+	})}\n\n`);
+	events.push(`data: ${JSON.stringify({
+		id: "chatcmpl-hotfix",
+		model,
+		choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+	})}\n\n`);
+	events.push("data: [DONE]\n\n");
+	return events.join("");
+}
+
+async function startSseServer(body: string): Promise<{
+	server: Server;
+	baseUrl: string;
+}> {
+	const server = createServer((_request, response) => {
+		response.writeHead(200, { "content-type": "text/event-stream" });
+		response.end(body);
+	});
+	await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+	const address = server.address();
+	assert.ok(address && typeof address !== "string");
+	return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function closeServer(server: Server): Promise<void> {
+	await new Promise<void>((resolveClose, rejectClose) => {
+		server.close((error) => error ? rejectClose(error) : resolveClose());
+	});
+}
+
+test("Pi 0.84.2 AI stream transforms are exact-version, idempotent, and fail closed", () => {
+	for (const root of [piAiRoot, nestedPiAiRoot]) {
+		const manifest = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+		assert.equal(manifest.version, PI_AI_FORWARD_FIX_REQUIRED_VERSION);
+	}
+	assert.equal(PI_AI_FORWARD_FIX_REQUIRED_VERSION, "0.84.2");
+
+	for (const relativePath of [
+		"dist/api/openai-completions.js",
+		"dist/api/openai-responses.js",
+	]) {
+			const source = readPiAiSource(relativePath);
+			const patched = patchPiAiForwardFixSource(relativePath, source);
+			assert.equal(patched, source, `${relativePath} should already carry the hotfix`);
+			assert.doesNotThrow(() => assertPiAiForwardFixSource(relativePath, patched));
+			assert.equal(patchPiAiForwardFixSource(relativePath, patched), patched);
+		}
+
+	const completionsPath = "dist/api/openai-completions.js";
+	const unsupportedCompletions = readPiAiSource(completionsPath).replace(
+		"                finalizeOpenAiReasoningDetails(block);\n                delete block.index;",
+		"                delete block.index;",
+	);
+	assert.throws(
+		() => patchPiAiForwardFixSource(completionsPath, unsupportedCompletions),
+		/Unsupported Pi 0\.84\.2 OpenAI structured reasoning stream accumulator layout|semantic fragment/,
+	);
+	const brokenCompletions = patchPiAiForwardFixSource(
+		completionsPath,
+		readPiAiSource(completionsPath),
+	).replace(
+		"                finalizeOpenAiReasoningDetails(block);\n                delete block.index;",
+		"                delete block.index;",
+	);
+	assert.throws(
+		() => assertPiAiForwardFixSource(completionsPath, brokenCompletions),
+		/semantic fragment/,
+	);
+
+	const responsesPath = "dist/api/openai-responses.js";
+	const unsupportedResponses = readPiAiSource(responsesPath).replace(
+		"if (options?.toolChoice !== undefined && toolPlacement.immediate.length > 0)",
+		"if (options?.toolChoice !== undefined && true)",
+	);
+	assert.throws(
+		() => patchPiAiForwardFixSource(responsesPath, unsupportedResponses),
+		/expected exactly one semantic fragment|retained no-tools tool_choice/,
+	);
+	const brokenResponses = patchPiAiForwardFixSource(
+		responsesPath,
+		readPiAiSource(responsesPath),
+	).replace(
+		"if (options?.toolChoice !== undefined && toolPlacement.immediate.length > 0)",
+		"if (options?.toolChoice !== undefined)",
+	);
+	assert.throws(
+		() => assertPiAiForwardFixSource(responsesPath, brokenResponses),
+		/missing|retained no-tools tool_choice|expected exactly one semantic fragment/,
+	);
+});
+
+test("structured reasoning preserves ordered replay and Gemini signatures", async (t) => {
+	const textFirst = { type: "reasoning.text", text: "Checked", index: 0 };
+	const textSecond = {
+		type: "reasoning.text",
+		text: " sources.",
+		id: "reasoning-text-1",
+		format: "openai-responses-v1",
+		index: 0,
+		signature: "sha256:text-signature",
+	};
+	const summaryFirst = { type: "reasoning.summary", summary: "Verified", index: 1 };
+	const summarySecond = {
+		type: "reasoning.summary",
+		summary: " evidence.",
+		id: "reasoning-summary-1",
+		format: "openai-responses-v1",
+		index: 1,
+	};
+	const encrypted = {
+		type: "reasoning.encrypted",
+		id: "call_1",
+		data: "encrypted-reasoning",
+		index: 2,
+	};
+	const expectedDetails = [
+		{
+			type: "reasoning.text",
+			text: "Checked sources.",
+			index: 0,
+			signature: "sha256:text-signature",
+			id: "reasoning-text-1",
+			format: "openai-responses-v1",
+		},
+		{
+			type: "reasoning.summary",
+			summary: "Verified evidence.",
+			index: 1,
+			id: "reasoning-summary-1",
+			format: "openai-responses-v1",
+		},
+		encrypted,
+	];
+	const firstGeminiSignature = "gemini-first-signature";
+	const laterGeminiSignature = "gemini-later-signature";
+	const body = sseBody([
+		{ reasoning: "Checked sources.", reasoning_details: [textFirst] },
+		{ reasoning_details: [textSecond, summaryFirst, summarySecond, encrypted] },
+		{
+			tool_calls: [{
+				index: 0,
+				id: "call_1",
+				type: "function",
+				function: { name: "read", arguments: "{\"path\":\"README.md\"}" },
+				extra_content: { google: { thought_signature: firstGeminiSignature } },
+			}],
+		},
+		{
+			tool_calls: [{
+				index: 0,
+				id: "call_1",
+				type: "function",
+				function: { name: "read", arguments: "" },
+				extra_content: { google: { thought_signature: laterGeminiSignature } },
+			}],
+		},
+	], "google/gemini-3-test").replace('"finish_reason":"stop"', '"finish_reason":"tool_calls"');
+	const { server, baseUrl } = await startSseServer(body);
+	t.after(() => closeServer(server));
+
+	const openAiCompletions = await importPatchedPiAiApi(
+		"dist/api/openai-completions.js",
+		"reasoning-semantics",
+	);
+	const model = openAiCompletionsModel("openrouter", "google/gemini-3-test", baseUrl);
+	const first = await openAiCompletions.streamSimple(
+		model,
+		{
+			messages: [{ role: "user", content: "research", timestamp: 0 }],
+			tools: [{
+				name: "read",
+				description: "Read a source",
+				parameters: { type: "object", properties: { path: { type: "string" } } },
+			}],
+		},
+		{ apiKey: "test" },
+	).result();
+	const thinking = first.content.find((block: { type: string }) => block.type === "thinking");
+	const toolCall = first.content.find((block: { type: string }) => block.type === "toolCall");
+	assert.deepEqual(thinking, {
+		type: "thinking",
+		thinking: "Checked sources.",
+		thinkingSignature: JSON.stringify(expectedDetails),
+	});
+	assert.equal(toolCall?.thoughtSignature, firstGeminiSignature);
+
+	let replayPayload: any;
+	await openAiCompletions.streamSimple(
+		model,
+		{ messages: [JSON.parse(JSON.stringify(first))] },
+		{
+			apiKey: "test",
+			onPayload: (payload: unknown) => {
+				replayPayload = payload;
+				throw new Error("same-model replay captured");
+			},
+		},
+	).result();
+	assert.deepEqual(replayPayload.messages[0].reasoning_details, expectedDetails);
+	assert.equal("reasoning" in replayPayload.messages[0], false);
+	assert.deepEqual(replayPayload.messages[0].tool_calls[0].extra_content, {
+		google: { thought_signature: firstGeminiSignature },
+	});
+
+	let crossModelPayload: any;
+	await openAiCompletions.streamSimple(
+		{ ...model, id: "google/gemini-3-other" },
+		{ messages: [JSON.parse(JSON.stringify(first))] },
+		{
+			apiKey: "test",
+			onPayload: (payload: unknown) => {
+				crossModelPayload = payload;
+				throw new Error("cross-model replay captured");
+			},
+		},
+	).result();
+	assert.equal("reasoning_details" in crossModelPayload.messages[0], false);
+});
+
+test("structured reasoning serializes partial replay data at the error boundary", async (t) => {
+	const encrypted = {
+		type: "reasoning.encrypted",
+		id: "partial-reasoning",
+		data: "partial-ciphertext",
+	};
+	const body = [
+		`data: ${JSON.stringify({
+			id: "chatcmpl-partial",
+			model: "research-model",
+			choices: [{
+				index: 0,
+				delta: { reasoning_details: [encrypted] },
+				finish_reason: null,
+			}],
+		})}\n\n`,
+		"data: [DONE]\n\n",
+	].join("");
+	const { server, baseUrl } = await startSseServer(body);
+	t.after(() => closeServer(server));
+	const openAiCompletions = await importPatchedPiAiApi(
+		"dist/api/openai-completions.js",
+		"reasoning-error-boundary",
+	);
+	const result = await openAiCompletions.streamSimple(
+		openAiCompletionsModel("custom-gateway", "research-model", baseUrl),
+		{ messages: [{ role: "user", content: "research", timestamp: 0 }] },
+		{ apiKey: "test" },
+	).result();
+	assert.equal(result.stopReason, "error");
+	assert.match(result.errorMessage ?? "", /Stream ended without finish_reason/);
+	assert.deepEqual(result.content.find((block: { type: string }) => block.type === "thinking"), {
+		type: "thinking",
+		thinking: "",
+		thinkingSignature: JSON.stringify([encrypted]),
+	});
+});
+
+test("structured reasoning serialization work stays constant as streams scale", async () => {
+	const openAiCompletions = await importPatchedPiAiApi(
+		"dist/api/openai-completions.js",
+		"reasoning-scaling",
+	);
+	const counts: Array<{ size: number; parses: number; serializations: number }> = [];
+
+	for (const size of [64, 2048]) {
+		const details = Array.from({ length: size }, (_value, index) => ({
+			type: "reasoning.encrypted",
+			id: `reasoning-${index}`,
+			data: `ciphertext-${index}`,
+			index,
+		}));
+		const { server, baseUrl } = await startSseServer(sseBody([{ reasoning_details: details }]));
+		const originalParse = JSON.parse;
+		const originalStringify = JSON.stringify;
+		let structuredParses = 0;
+		let structuredSerializations = 0;
+		JSON.parse = ((text: string, reviver?: (this: any, key: string, value: any) => any) => {
+			if (typeof text === "string" && text.startsWith('[{"type":"reasoning.')) {
+				structuredParses++;
+			}
+			return originalParse(text, reviver);
+		}) as typeof JSON.parse;
+		JSON.stringify = ((value: any, ...args: any[]) => {
+			if (
+				Array.isArray(value) &&
+				value.length > 0 &&
+				value.every((detail) => typeof detail?.type === "string" && detail.type.startsWith("reasoning."))
+			) {
+				structuredSerializations++;
+			}
+			return originalStringify(value, ...args);
+		}) as typeof JSON.stringify;
+		try {
+			const result = await openAiCompletions.streamSimple(
+				openAiCompletionsModel("custom-gateway", "research-model", baseUrl),
+				{ messages: [{ role: "user", content: "research", timestamp: 0 }] },
+				{ apiKey: "test" },
+			).result();
+			assert.equal(result.stopReason, "stop");
+		} finally {
+			JSON.parse = originalParse;
+			JSON.stringify = originalStringify;
+			await closeServer(server);
+		}
+		counts.push({
+			size,
+			parses: structuredParses,
+			serializations: structuredSerializations,
+		});
+	}
+
+	assert.deepEqual(counts, [
+		{ size: 64, parses: 0, serializations: 1 },
+		{ size: 2048, parses: 0, serializations: 1 },
+	]);
+});
+
+test("OpenAI Responses omits no-tools tool_choice and preserves tool-enabled choice", async () => {
+	const openAiResponses = await importPatchedPiAiApi(
+		"dist/api/openai-responses.js",
+		"responses-tool-choice",
+	);
+	const model = openAiResponsesModel();
+	let noToolsPayload: any;
+	const noToolsResult = await openAiResponses.streamSimple(
+		model,
+		{ messages: [{ role: "user", content: "Summarize the conversation", timestamp: 0 }] },
+		{
+			apiKey: "test",
+			toolChoice: "none",
+			onPayload: (payload: unknown) => {
+				noToolsPayload = payload;
+				throw new Error("no-tools Responses payload captured");
+			},
+		},
+	).result();
+	assert.match(noToolsResult.errorMessage ?? "", /no-tools Responses payload captured/);
+	assert.equal("tools" in noToolsPayload, false);
+	assert.equal("tool_choice" in noToolsPayload, false);
+
+	let toolsPayload: any;
+	const toolsResult = await openAiResponses.streamSimple(
+		model,
+		{
+			messages: [{ role: "user", content: "Read the source", timestamp: 0 }],
+			tools: [{
+				name: "read",
+				description: "Read a source",
+				parameters: {
+					type: "object",
+					properties: { path: { type: "string" } },
+					required: ["path"],
+				},
+			}],
+		},
+		{
+			apiKey: "test",
+			toolChoice: "required",
+			onPayload: (payload: unknown) => {
+				toolsPayload = payload;
+				throw new Error("tool-enabled Responses payload captured");
+			},
+		},
+	).result();
+	assert.match(toolsResult.errorMessage ?? "", /tool-enabled Responses payload captured/);
+	assert.equal(toolsPayload.tool_choice, "required");
+	assert.equal(toolsPayload.tools.length, 1);
+});

--- a/tests/pi-compaction-integrity-hotfixes.test.ts
+++ b/tests/pi-compaction-integrity-hotfixes.test.ts
@@ -1,0 +1,493 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+	cpSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import {
+	assertPiCompactionToolsPatchedSource,
+	PI_COMPACTION_TOOLS_PATCH_MARKERS,
+	PI_COMPACTION_TOOLS_PATCH_TARGETS,
+	PI_COMPACTION_TOOLS_REQUIRED_VERSION,
+	patchPiCompactionToolsSource,
+} from "../scripts/lib/pi-compaction-tools-patch.mjs";
+import {
+	assertPiCompactionToolsPackageTree,
+	verifyPiCompactionToolsBehavior,
+} from "../scripts/lib/pi-compaction-tools-verifier.mjs";
+
+const appRoot = process.cwd();
+const installedPackageRoot = resolve(
+	appRoot,
+	"node_modules",
+	"@earendil-works",
+	"pi-coding-agent",
+);
+
+function sha256(path: string): string {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function assistantMessage(model: Record<string, unknown>, text: string, stopReason = "stop") {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 10,
+			output: 10,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 20,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function summaryStream(model: Record<string, unknown>, summaries: string[]) {
+	let index = 0;
+	return async () => ({
+		result: async () => assistantMessage(model, summaries[Math.min(index++, summaries.length - 1)] ?? ""),
+	});
+}
+
+function compactionPreparation(options: {
+	isSplitTurn?: boolean;
+	file?: string;
+	settings?: { enabled: boolean; reserveTokens: number; keepRecentTokens: number };
+} = {}) {
+	return {
+		firstKeptEntryId: "kept-entry",
+		messagesToSummarize: options.isSplitTurn
+			? []
+			: [{ role: "user" as const, content: "Preserve this research history.", timestamp: 1 }],
+		turnPrefixMessages: options.isSplitTurn
+			? [{ role: "user" as const, content: "Verify the BRCA1 evidence trail.", timestamp: 1 }]
+			: [],
+		isSplitTurn: options.isSplitTurn ?? false,
+		tokensBefore: 7000,
+		fileOps: {
+			read: new Set(options.file ? [options.file] : []),
+			written: new Set<string>(),
+			edited: new Set<string>(),
+		},
+		settings: options.settings ?? { enabled: true, reserveTokens: 2048, keepRecentTokens: 4096 },
+	};
+}
+
+const checkpointSummary = [
+	"## Goal",
+	"Verify the BRCA1 claim against the primary paper.",
+	"",
+	"## Progress",
+	"- Located the cited experiment and recorded its DOI.",
+	"",
+	"## Next Steps",
+	"1. Reproduce the reported confidence interval.",
+].join("\n");
+
+const turnPrefixSummary = [
+	"## Original Request",
+	"Verify the BRCA1 evidence trail.",
+	"",
+	"## Early Progress",
+	"- Located the paper and extracted the reported cohort size.",
+	"",
+	"## Context for Suffix",
+	"- The retained work still needs an independent confidence-interval check.",
+].join("\n");
+
+async function withPatchedFixture(
+	run: (fixtureAppRoot: string, packageRoot: string) => Promise<void>,
+): Promise<void> {
+	const fixtureAppRoot = mkdtempSync(resolve(appRoot, ".pi-compaction-hotfix-"));
+	const packageRoot = resolve(
+		fixtureAppRoot,
+		"node_modules",
+		"@earendil-works",
+		"pi-coding-agent",
+	);
+	try {
+		cpSync(installedPackageRoot, packageRoot, { recursive: true });
+		for (const relativePath of PI_COMPACTION_TOOLS_PATCH_TARGETS) {
+			const target = resolve(packageRoot, ...relativePath.split("/"));
+			const source = readFileSync(target, "utf8");
+			writeFileSync(target, patchPiCompactionToolsSource(relativePath, source));
+		}
+		await run(fixtureAppRoot, packageRoot);
+	} finally {
+		rmSync(fixtureAppRoot, { recursive: true, force: true });
+	}
+}
+
+test("Pi 0.84.2 compaction hotfix transforms are exact, idempotent, and fail closed", async () => {
+	assert.equal(PI_COMPACTION_TOOLS_REQUIRED_VERSION, "0.84.2");
+	const installedHashes = new Map<string, string>();
+	for (const relativePath of PI_COMPACTION_TOOLS_PATCH_TARGETS) {
+		const target = resolve(installedPackageRoot, ...relativePath.split("/"));
+		installedHashes.set(relativePath, sha256(target));
+		const source = readFileSync(target, "utf8");
+		const patched = patchPiCompactionToolsSource(relativePath, source);
+		assert.equal(patchPiCompactionToolsSource(relativePath, patched), patched, relativePath);
+		assert.doesNotThrow(() => assertPiCompactionToolsPatchedSource(relativePath, patched));
+	}
+
+	const compactionPath = resolve(
+		installedPackageRoot,
+		"dist/core/compaction/compaction.js",
+	);
+	const unsupportedLayout = readFileSync(compactionPath, "utf8").replace(
+		"return contextTokens > contextWindow - effectiveSettings.reserveTokens;",
+		"return contextTokens >= contextWindow - effectiveSettings.reserveTokens;",
+	);
+	assert.throws(
+		() => patchPiCompactionToolsSource("dist/core/compaction/compaction.js", unsupportedLayout),
+		/effectiveSettings\.reserveTokens/,
+	);
+
+	const patchedCompaction = patchPiCompactionToolsSource(
+		"dist/core/compaction/compaction.js",
+		readFileSync(compactionPath, "utf8"),
+	);
+	assert.throws(
+		() => assertPiCompactionToolsPatchedSource(
+			"dist/core/compaction/compaction.js",
+			patchedCompaction.replace(
+				"const keepRecentCeiling = Math.max(1, windowTokens - 2 * reserveTokens);",
+				"const keepRecentCeiling = Math.max(1, windowTokens - reserveTokens);",
+			),
+		),
+		/keepRecentCeiling/,
+	);
+	assert.throws(
+		() => assertPiCompactionToolsPatchedSource(
+				"dist/core/compaction/compaction.js",
+				patchedCompaction.replace(
+					'const usabilityFailure = getSummaryUsabilityFailure(textContent, "Summarization", undefined, conversationText.length + (previousSummary?.length ?? 0));',
+					"const usabilityFailure = undefined;",
+				),
+		),
+		/getSummaryUsabilityFailure/,
+	);
+	assert.throws(
+		() => assertPiCompactionToolsPatchedSource(
+			"dist/core/compaction/compaction.js",
+			patchedCompaction.replace(
+				"return Math.min(512, Math.max(64, Math.floor(sourceCharacters / 200)));",
+				"return 64;",
+			),
+		),
+		/sourceCharacters \/ 200/,
+	);
+
+	await withPatchedFixture(async (fixtureAppRoot) => {
+		assert.doesNotThrow(() => assertPiCompactionToolsPackageTree(
+			fixtureAppRoot,
+			(path) => readFileSync(path, "utf8"),
+		));
+		await verifyPiCompactionToolsBehavior(fixtureAppRoot);
+		assert.throws(
+			() => assertPiCompactionToolsPackageTree(
+				fixtureAppRoot,
+				(path) => path.endsWith("pi-coding-agent/package.json")
+					? JSON.stringify({ ...JSON.parse(readFileSync(path, "utf8")), version: "0.84.3" })
+					: readFileSync(path, "utf8"),
+			),
+			/0\.84\.3.*0\.84\.2|0\.84\.2.*0\.84\.3/,
+		);
+	});
+
+	for (const [relativePath, hash] of installedHashes) {
+		assert.equal(
+			sha256(resolve(installedPackageRoot, ...relativePath.split("/"))),
+			hash,
+			`installed runtime changed: ${relativePath}`,
+		);
+	}
+});
+
+test("model-bounded budgets preserve large-context behavior and make 8K compaction viable", async () => {
+	await withPatchedFixture(async (_fixtureAppRoot, packageRoot) => {
+		const compaction = await import(
+			`${pathToFileURL(resolve(packageRoot, "dist/core/compaction/compaction.js")).href}?budget=${Date.now()}`
+		);
+		const defaults = compaction.DEFAULT_COMPACTION_SETTINGS;
+		assert.deepEqual(
+			compaction.getEffectiveCompactionSettings(defaults, 8192),
+			{ enabled: true, reserveTokens: 2048, keepRecentTokens: 4096 },
+		);
+		assert.equal(compaction.shouldCompact(0, 8192, defaults), false);
+		assert.equal(compaction.shouldCompact(6144, 8192, defaults), false);
+		assert.equal(compaction.shouldCompact(6145, 8192, defaults), true);
+
+		assert.strictEqual(
+			compaction.getEffectiveCompactionSettings(defaults, 128000),
+			defaults,
+			"normal contexts must retain the exact existing settings object",
+		);
+		assert.equal(compaction.shouldCompact(111616, 128000, defaults), false);
+		assert.equal(compaction.shouldCompact(111617, 128000, defaults), true);
+
+		const pathEntries = [
+			{
+				type: "message",
+				id: "entry-1",
+				parentId: null,
+				timestamp: new Date(1).toISOString(),
+				message: { role: "user", content: "A".repeat(12000), timestamp: 1 },
+			},
+			{
+				type: "message",
+				id: "entry-2",
+				parentId: "entry-1",
+				timestamp: new Date(2).toISOString(),
+				message: { role: "assistant", content: [{ type: "text", text: "B".repeat(8000) }], timestamp: 2 },
+			},
+			{
+				type: "message",
+				id: "entry-3",
+				parentId: "entry-2",
+				timestamp: new Date(3).toISOString(),
+				message: { role: "user", content: "C".repeat(12000), timestamp: 3 },
+			},
+			{
+				type: "message",
+				id: "entry-4",
+				parentId: "entry-3",
+				timestamp: new Date(4).toISOString(),
+				message: { role: "assistant", content: [{ type: "text", text: "D".repeat(8000) }], timestamp: 4 },
+			},
+		];
+		const preparation = compaction.prepareCompaction(pathEntries, defaults, 8192);
+		assert.ok(preparation, "expected a small-context compaction preparation");
+		assert.deepEqual(preparation.settings, {
+			enabled: true,
+			reserveTokens: 2048,
+			keepRecentTokens: 4096,
+		});
+
+		const agentSessionSource = readFileSync(resolve(packageRoot, "dist/core/agent-session.js"), "utf8");
+		assert.equal(
+			agentSessionSource.split(PI_COMPACTION_TOOLS_PATCH_MARKERS.contextCallers).length - 1,
+			2,
+			"manual and automatic compaction must both pass the active model context",
+		);
+	});
+});
+
+test("history, split-turn, and branch compaction reject unusable checkpoints", async () => {
+	await withPatchedFixture(async (_fixtureAppRoot, packageRoot) => {
+		const nonce = Date.now();
+		const compaction = await import(
+			`${pathToFileURL(resolve(packageRoot, "dist/core/compaction/compaction.js")).href}?integrity=${nonce}`
+		);
+		const branch = await import(
+			`${pathToFileURL(resolve(packageRoot, "dist/core/compaction/branch-summarization.js")).href}?integrity=${nonce}`
+		);
+		const model = {
+			id: "research-checkpoint-test",
+			name: "Research Checkpoint Test",
+			api: "openai-completions",
+			provider: "test",
+			baseUrl: "https://example.invalid/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 8192,
+			maxTokens: 2048,
+		};
+
+		assert.match(
+			compaction.getSummaryUsabilityFailure("", "Summarization") ?? "",
+			/empty or file-list-only checkpoint/,
+		);
+		assert.match(
+			compaction.getSummaryUsabilityFailure(
+				"<read-files>\npapers/brca1.pdf\n</read-files>",
+				"Summarization",
+			) ?? "",
+			/empty or file-list-only checkpoint/,
+		);
+		assert.match(
+			compaction.getSummaryUsabilityFailure(
+				"The paper was read and there may be more work to do.",
+				"Summarization",
+			) ?? "",
+			/implausibly small checkpoint|structurally unusable checkpoint/,
+		);
+		assert.match(
+			compaction.getSummaryUsabilityFailure(
+				[
+					"## Goal",
+					"(none)",
+					"## Progress",
+					"### Done",
+					"- [x] none",
+					"## Next Steps",
+					"1. none",
+				].join("\n"),
+				"Summarization",
+			) ?? "",
+			/implausibly small checkpoint|structurally unusable checkpoint/,
+		);
+		assert.equal(
+			compaction.getSummaryUsabilityFailure(checkpointSummary, "Summarization"),
+			undefined,
+		);
+		const tinyStructuredStub = [
+			"## Goal",
+			"Research",
+			"## Progress",
+			"Started",
+			"## Next Steps",
+			"Continue",
+		].join("\n");
+		assert.match(
+			compaction.getSummaryUsabilityFailure(
+				tinyStructuredStub,
+				"Summarization",
+				undefined,
+				100_000,
+			) ?? "",
+			/implausibly small checkpoint/,
+		);
+		await assert.rejects(
+			() => compaction.generateSummaryWithUsage(
+				[{ role: "user", content: "A".repeat(100_000), timestamp: 1 }],
+				model,
+				2048,
+				"test",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				"off",
+				summaryStream(model, [tinyStructuredStub]),
+			),
+			/implausibly small checkpoint/,
+		);
+		await assert.rejects(
+			() => compaction.generateSummaryWithUsage(
+				[{ role: "user", content: "Record one new observation.", timestamp: 1 }],
+				model,
+				2048,
+				"test",
+				undefined,
+				undefined,
+				undefined,
+				`## Goal\n${"A".repeat(100_000)}\n## Progress\nPrior work\n## Next Steps\nContinue`,
+				"off",
+				summaryStream(model, [checkpointSummary]),
+			),
+			/implausibly small checkpoint/,
+		);
+
+		await assert.rejects(
+			() => compaction.compact(
+				compactionPreparation({ file: "papers/brca1.pdf" }),
+				model,
+				"test",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				summaryStream(model, [""]),
+			),
+			/empty or file-list-only checkpoint/,
+		);
+		await assert.rejects(
+			() => compaction.compact(
+				compactionPreparation(),
+				model,
+				"test",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				summaryStream(model, ["The paper was read, but the checkpoint has no structure."]),
+			),
+			/implausibly small checkpoint|structurally unusable checkpoint/,
+		);
+		const historyResult = await compaction.compact(
+			compactionPreparation({ file: "papers/brca1.pdf" }),
+			model,
+			"test",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			summaryStream(model, [checkpointSummary]),
+		);
+		assert.match(historyResult.summary, /Verify the BRCA1 claim/);
+		assert.match(historyResult.summary, /<read-files>\npapers\/brca1\.pdf\n<\/read-files>/);
+
+		await assert.rejects(
+			() => compaction.compact(
+				compactionPreparation({ isSplitTurn: true }),
+				model,
+				"test",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				summaryStream(model, [""]),
+			),
+			/empty or file-list-only checkpoint/,
+		);
+		const splitResult = await compaction.compact(
+			compactionPreparation({ isSplitTurn: true }),
+			model,
+			"test",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			summaryStream(model, [turnPrefixSummary]),
+		);
+		assert.match(splitResult.summary, /Turn Context \(split turn\)/);
+		assert.match(splitResult.summary, /independent confidence-interval check/);
+
+		const entries = [{
+			type: "message",
+			id: "branch-entry",
+			parentId: null,
+			timestamp: new Date(1).toISOString(),
+			message: { role: "user", content: "Investigate the alternate BRCA1 method.", timestamp: 1 },
+		}];
+		const unusableBranch = await branch.generateBranchSummary(entries, {
+			model,
+			apiKey: "test",
+			streamFn: summaryStream(model, [""]),
+		});
+		assert.match(unusableBranch.error ?? "", /empty or file-list-only checkpoint/);
+		const acceptedBranch = await branch.generateBranchSummary(entries, {
+			model,
+			apiKey: "test",
+			streamFn: summaryStream(model, [checkpointSummary]),
+		});
+		assert.match(acceptedBranch.summary ?? "", /Summary of that exploration/);
+		assert.match(acceptedBranch.summary ?? "", /Reproduce the reported confidence interval/);
+		const customReplacementSummary =
+			"The alternate branch established that the primary paper used a distinct BRCA1 cohort, recorded the exact DOI and sample size, and left an independent confidence-interval reproduction as the next research step.";
+		const customBranch = await branch.generateBranchSummary(entries, {
+			model,
+			apiKey: "test",
+			customInstructions: "Return one concise paragraph with the result and next research step.",
+			replaceInstructions: true,
+			streamFn: summaryStream(model, [customReplacementSummary]),
+		});
+		assert.equal(customBranch.error, undefined);
+		assert.match(customBranch.summary ?? "", /alternate branch established/);
+	});
+});

--- a/tests/runtime-workspace-lock.test.ts
+++ b/tests/runtime-workspace-lock.test.ts
@@ -88,11 +88,11 @@ test("vendored runtime uses a committed exact dependency lock", () => {
 			)?.integrity,
 		},
 		{
-			version: "2.13.1",
+			version: "2.14.0",
 			resolved:
-				"https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.13.1.tgz",
+				"https://registry.npmjs.org/@llamaindex/liteparse/-/liteparse-2.14.0.tgz",
 			integrity:
-				"sha512-EtMFEYFZIY+Gpj6nebvyiIkU9NTmLG5CXe2WpYy5S0pjCLfFgW0Tn9iN68ik3QIk64ELSdLJlgijSzCzfSpeoQ==",
+				"sha512-lIFBbTRs87Bpp45Lm986hUDEPndm85pT9l/BM1dtWhQs0zTLEkpHLrgbOxGG2rjBqDgJM5fdChT8LWUd4ZThWA==",
 		},
 	);
 	assert.equal(

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,30 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.44 - 2026-08-26
+
+### Research continuity
+
+- Stopping a tool run now ends the active Pi loop before queued steering or follow-up research input can be drained into an already-aborted model call. The queued input remains available for the next turn instead of producing a second spurious cancellation.
+
+### Compaction integrity
+
+- Small-context local and proxy models now bound compaction reserve and retained-history budgets to the model's actual context window, preventing empty or short sessions from compacting continuously.
+- Empty or structurally unusable summaries no longer replace research history. OpenAI Responses providers such as Grok also omit `tool_choice` when a compaction request has no tools.
+
+### Model reliability
+
+- OpenAI-compatible structured reasoning deltas are accumulated without reparsing and reserializing the complete history for every streamed detail, preventing long reasoning streams from blocking the event loop while preserving same-model replay.
+
+### Document research
+
+- Updated the bundled LiteParse runtime to `2.14.0`. OCR rasterization now runs in bounded worker-sized rounds, and dense PDF layout deduplication avoids quadratic work. Existing parse, search, and screenshot interfaces are unchanged.
+
+### Validation
+
+- Added executable abort-queue, Responses payload, structured-reasoning scale, small-context compaction, and summary-usability regressions across the maintained Pi runtime.
+- Re-ran installed document parsing, page-count, search, screenshot, package-artifact, runtime, and clean-consumer verification against LiteParse `2.14.0`.
+
 ## v0.3.43 - 2026-08-25
 
 ### Installation reliability


### PR DESCRIPTION
## Core research job

Preserve queued research input, reasoning metadata, and long-session context while keeping document ingestion bounded and auditable.

## What changed

- stop Pi after a tool-time abort before an already-cancelled signal consumes queued steering/follow-up input (upstream PR #8658)
- accumulate OpenAI-compatible structured reasoning in memory and serialize once per block instead of quadratic per-delta parse/stringify
- omit `tool_choice` from no-tool OpenAI Responses compaction requests (upstream #8649/#8650)
- bound compaction reserve/retained-history budgets to the model context window
- reject empty, structurally unusable, and implausibly small history/split-turn/branch checkpoints, including incremental summaries, while preserving documented replacement prompts
- update all seven LiteParse platforms and the bundled runtime to `2.14.0` for worker-bounded OCR rasterization and non-quadratic dense-layout processing
- strengthen package/runtime/native lock and semantic verification

## Verification

Exact head: `ea8a86ed156034674ec33137d87083e5591af586`

- focused abort/reasoning/Responses/compaction/LiteParse regressions green
- `npm test`: `951/951`
- typecheck, build, architecture check green
- website lint/typecheck/build: 34 pages
- root/runtime/website production audits: 0 vulnerabilities
- dry and real pack: 116,527,953 bytes, 29,184 files
- tarball SHA-256: `f75b0511d86e244f5f6f42c75164c43524ce626f8b9fd3718e2a1f5b8414cdaf`
- exact clean consumer: package/runtime/provider/tool verification and LiteParse parse/search/screenshot green
- adversarial review findings repaired: prior-summary size bypass, replacement-prompt compatibility, native-lock drift, and fail-open threshold formula

Daytona exact-head proof and required GitHub matrices are release gates before merge.
