### PR TITLE
Harden release runtime timeouts for 0.3.45

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -509,7 +509,11 @@ jobs:
           $version = node -p "require('./package.json').version"
           $tmp = Join-Path $env:RUNNER_TEMP ("feynman-smoke-" + [guid]::NewGuid().ToString("N"))
           New-Item -ItemType Directory -Path $tmp | Out-Null
-          Expand-Archive -LiteralPath "dist/release/feynman-$version-win32-x64.zip" -DestinationPath $tmp -Force
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          [System.IO.Compression.ZipFile]::ExtractToDirectory(
+            (Join-Path (Get-Location) "dist/release/feynman-$version-win32-x64.zip"),
+            $tmp
+          )
           $bundleRoot = Join-Path $tmp "feynman-$version-win32-x64"
           & (Join-Path $bundleRoot "feynman.cmd") --help | Select-Object -First 20
           if ($LASTEXITCODE -ne 0) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-26 08:48 EDT — pi-research-runtime-integrity-0.3.44-release
+
+- Persistence: PR `#257` merged the initial exact candidate `ea8a86ed156034674ec33137d87083e5591af586` as `44cb69406b1b1f0f333f4edcf3e2ee7984ba521f`. Post-merge review cancelled the first publish before publication; PR `#258` then merged exact blocker-repair head `00e8c24536a0e5accae00ca723dc932a36b56c9b` as `999243d042840317d95e153a9b9718f86b9a2fda`.
+- Verification: PR `#258` run `32957057912`, CodeQL, Vercel, all six Node/OS consumers, and Windows native installer passed. Exact-head Daytona proof covered the cumulative runtime plus clean installed telemetry fallback and Bedrock image paths; sandboxes were deleted. Main publish run `32961781923` passed source verification, all six consumers, all five native bundles, npm publication, GitHub release, and published-state verification.
+- Publication: GitHub release `v0.3.44` (`377124175`) and npm latest `0.3.44` agree on merge `999243d`; npm integrity is `sha512-GX1SVLv5P7NJJB7Yzm8mhhC0rzWiC4rSXvGEzaQlETHt4u1ACisC6k8TbDJ0AVbL5IUQnjyk3WeSi7wr7c9Haw==` and shasum `bf58fccabd542c9c9ab884c7a11d3c971ca30108`. All five native asset digests match committed `SHA256SUMS`.
+- Live: A fresh registry consumer passed zero-vulnerability audit, package/runtime/tool/provider verification, and LiteParse `2.14.0` parse/search/screenshot checks. Installer and release-document endpoints return HTTP `200`; main CodeQL passed.
+- Preservation: Root main is clean and synchronized; the independently dirty nested `website` checkout remains preserved at `67186845`. State: `verified`. Next: resume normal intake monitoring.
+
 ### 2026-08-26 04:00 EDT — pi-release-blockers-0.3.44
 
 - Intake: Cancelled publish run `32938502008` before npm/GitHub publication after post-merge adversarial and upstream review found new release blockers; npm/GitHub latest remain `0.3.43`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Use this file to track chronology, not release notes. Keep entries short, factua
 - Live: A fresh registry consumer passed zero-vulnerability audit, package/runtime/tool/provider verification, and LiteParse `2.14.0` parse/search/screenshot checks. Installer and release-document endpoints return HTTP `200`; main CodeQL passed.
 - Preservation: Root main is clean and synchronized; the independently dirty nested `website` checkout remains preserved at `67186845`. State: `verified`. Next: resume normal intake monitoring.
 
+### 2026-08-26 08:03 EDT — release-runtime-timeouts-0.3.45
+
+- Objective: Remove two release/runtime timeout hazards found during the intake sweep while preserving the independently dirty nested website checkout.
+- Changed: Publish Windows native smoke now extracts with .NET `System.IO.Compression.ZipFile`; source runtime archive rebuilds now use the shared fifteen-minute runtime restore timeout; added focused workflow/runtime regressions and prepared `0.3.45` release notes.
+- Verified: Focused release/runtime/content tests pass `55/55`; full `npm test` passes `971/971`; typecheck, build, architecture check, website lint/typecheck/build (`34` pages), root/site audits, and `git diff --check` pass. `npm outdated` reports expected non-security dependency drift only.
+- State: `unverified` for the committed exact head, clean-machine proof, PR CI, merge, publication, and release identity. Next: pack the exact candidate, run clean consumer/Daytona proof, then push, merge, publish, and verify `0.3.45`.
+
 ### 2026-08-26 04:00 EDT — pi-release-blockers-0.3.44
 
 - Intake: Cancelled publish run `32938502008` before npm/GitHub publication after post-merge adversarial and upstream review found new release blockers; npm/GitHub latest remain `0.3.43`.
@@ -4919,11 +4926,3 @@ Use this file to track chronology, not release notes. Keep entries short, factua
 - Package proof: Typecheck, build, architecture, website lint/typecheck/build (`34` pages), root/site/runtime/consumer audits, freshness review, and `git diff --check` pass. Dry and real packs match at `107,684,607` bytes, `287,530,283` unpacked bytes, and `29,128` entries; SHA-256 is `cbfe3653ca23930342e2c55544ad1ffe49e7bc64fa38cdc5f6e83f6ff38eb201`.
 - Installed proof: A clean tarball consumer passes version/help, package and search status, stale-Pi repair, package/archive verification, RPC extension and TypeBox checks, document parse/search/screenshot, and zero-vulnerability audits. Direct installed-runtime probes remove inline data URIs in readable mode, preserve raw responses, allow same-origin loopback Firecrawl redirects, and reject cross-origin loopback redirects plus loopback research targets.
 - State: `unverified` for exact committed Daytona, pull-request CI, merge, publication, and release identity. Next: commit the candidate, run the clean-machine ladder, then merge, publish, and reconcile `0.3.30`.
-
-
-### 2026-08-26 08:03 EDT — release-runtime-timeouts-0.3.45
-
-- Objective: Remove two release/runtime timeout hazards found during the intake sweep while preserving the independently dirty nested website checkout.
-- Changed: Publish Windows native smoke now extracts with .NET `System.IO.Compression.ZipFile`; source runtime archive rebuilds now use the shared fifteen-minute runtime restore timeout; added focused workflow/runtime regressions and prepared `0.3.45` release notes.
-- Verified: Focused release/runtime/content tests pass `55/55`; full `npm test` passes `971/971`; typecheck, build, architecture check, website lint/typecheck/build (`34` pages), root/site audits, and `git diff --check` pass. `npm outdated` reports expected non-security dependency drift only.
-- State: `unverified` for the committed exact head, clean-machine proof, PR CI, merge, publication, and release identity. Next: pack the exact candidate, run clean consumer/Daytona proof, then push, merge, publish, and verify `0.3.45`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4911,3 +4911,11 @@ Use this file to track chronology, not release notes. Keep entries short, factua
 - Package proof: Typecheck, build, architecture, website lint/typecheck/build (`34` pages), root/site/runtime/consumer audits, freshness review, and `git diff --check` pass. Dry and real packs match at `107,684,607` bytes, `287,530,283` unpacked bytes, and `29,128` entries; SHA-256 is `cbfe3653ca23930342e2c55544ad1ffe49e7bc64fa38cdc5f6e83f6ff38eb201`.
 - Installed proof: A clean tarball consumer passes version/help, package and search status, stale-Pi repair, package/archive verification, RPC extension and TypeBox checks, document parse/search/screenshot, and zero-vulnerability audits. Direct installed-runtime probes remove inline data URIs in readable mode, preserve raw responses, allow same-origin loopback Firecrawl redirects, and reject cross-origin loopback redirects plus loopback research targets.
 - State: `unverified` for exact committed Daytona, pull-request CI, merge, publication, and release identity. Next: commit the candidate, run the clean-machine ladder, then merge, publish, and reconcile `0.3.30`.
+
+
+### 2026-08-26 08:03 EDT — release-runtime-timeouts-0.3.45
+
+- Objective: Remove two release/runtime timeout hazards found during the intake sweep while preserving the independently dirty nested website checkout.
+- Changed: Publish Windows native smoke now extracts with .NET `System.IO.Compression.ZipFile`; source runtime archive rebuilds now use the shared fifteen-minute runtime restore timeout; added focused workflow/runtime regressions and prepared `0.3.45` release notes.
+- Verified: Focused release/runtime/content tests pass `55/55`; full `npm test` passes `971/971`; typecheck, build, architecture check, website lint/typecheck/build (`34` pages), root/site audits, and `git diff --check` pass. `npm outdated` reports expected non-security dependency drift only.
+- State: `unverified` for the committed exact head, clean-machine proof, PR CI, merge, publication, and release identity. Next: pack the exact candidate, run clean consumer/Daytona proof, then push, merge, publish, and verify `0.3.45`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,17 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
+## v0.3.45 - 2026-08-26
+
+### Release reliability
+
+- Windows publication smoke tests now use the supported .NET ZIP extractor instead of the pathologically slow PowerShell `Expand-Archive` cmdlet, so large native research bundles complete within the release job budget.
+- Source-checkout runtime archive rebuilds now use the same fifteen-minute timeout as exact locked runtime restores, preventing slow clean environments from silently falling back to an incomplete runtime.
+
+### Validation
+
+- Added workflow and runtime regressions that bind Windows native extraction and source-archive rebuilding to their supported timeout contracts.
+
 ## v0.3.44 - 2026-08-26
 
 ### Research continuity

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,7 +11,7 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 ### Release reliability
 
 - Windows publication smoke tests now use the supported .NET ZIP extractor instead of the pathologically slow PowerShell `Expand-Archive` cmdlet, so large native research bundles complete within the release job budget.
-- Source-checkout runtime archive rebuilds now use the same fifteen-minute timeout as exact locked runtime restores, preventing slow clean environments from silently falling back to an incomplete runtime.
+- Source-checkout runtime archive rebuilds now use the same fifteen-minute process budget as exact locked runtime restores, avoiding premature timeouts on slow clean environments while retaining the existing transactional exact-lock checks.
 
 ### Validation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.44",
+      "version": "0.3.45",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/scripts/lib/runtime-workspace-install.mjs
+++ b/scripts/lib/runtime-workspace-install.mjs
@@ -104,7 +104,7 @@ export function buildSourceRuntimeArchive(
 		{
 			cwd: appRoot,
 			stdio: ["ignore", "pipe", "pipe"],
-			timeout: 300000,
+			timeout: RUNTIME_WORKSPACE_PACKAGE_INSTALL_TIMEOUT_MS,
 			env,
 		},
 	);

--- a/tests/release-workflows.test.ts
+++ b/tests/release-workflows.test.ts
@@ -308,6 +308,11 @@ test("version reconciliation and post-publish verification cover all release sur
 	assert.match(publishWorkflow, /node-version-file: \.nvmrc/);
 	assert.match(publishWorkflow, /npx npm@11\.18\.0 publish/);
 	assert.match(publishWorkflow, /Windows native launcher failed --help/);
+	assert.match(
+		publishWorkflow,
+		/\[System\.IO\.Compression\.ZipFile\]::ExtractToDirectory/,
+	);
+	assert.doesNotMatch(publishWorkflow, /Expand-Archive/);
 	assert.doesNotMatch(publishWorkflow, /npm@latest/);
 	for (const workflow of [e2eWorkflow, publishWorkflow]) {
 		assert.doesNotMatch(workflow, /uses: actions\/[^@\s]+@v\d/);

--- a/tests/runtime-workspace-install.test.ts
+++ b/tests/runtime-workspace-install.test.ts
@@ -55,7 +55,10 @@ test("source checkout builds the exact authenticated runtime archive", () => {
 					]);
 					assert.equal(options.cwd, root);
 					assert.deepEqual(options.stdio, ["ignore", "pipe", "pipe"]);
-					assert.equal(options.timeout, 300000);
+					assert.equal(
+						options.timeout,
+						RUNTIME_WORKSPACE_PACKAGE_INSTALL_TIMEOUT_MS,
+					);
 					assert.equal(
 						options.env.FEYNMAN_RUNTIME_WORKSPACE_TARGET,
 						undefined,

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,6 +9,17 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
+## v0.3.45 - 2026-08-26
+
+### Release reliability
+
+- Windows publication smoke tests now use the supported .NET ZIP extractor instead of the pathologically slow PowerShell `Expand-Archive` cmdlet, so large native research bundles complete within the release job budget.
+- Source-checkout runtime archive rebuilds now use the same fifteen-minute timeout as exact locked runtime restores, preventing slow clean environments from silently falling back to an incomplete runtime.
+
+### Validation
+
+- Added workflow and runtime regressions that bind Windows native extraction and source-archive rebuilding to their supported timeout contracts.
+
 ## v0.3.44 - 2026-08-26
 
 ### Research continuity

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -14,7 +14,7 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 ### Release reliability
 
 - Windows publication smoke tests now use the supported .NET ZIP extractor instead of the pathologically slow PowerShell `Expand-Archive` cmdlet, so large native research bundles complete within the release job budget.
-- Source-checkout runtime archive rebuilds now use the same fifteen-minute timeout as exact locked runtime restores, preventing slow clean environments from silently falling back to an incomplete runtime.
+- Source-checkout runtime archive rebuilds now use the same fifteen-minute process budget as exact locked runtime restores, avoiding premature timeouts on slow clean environments while retaining the existing transactional exact-lock checks.
 
 ### Validation
 


### PR DESCRIPTION
## Core research job

Keep clean-machine research runtime and release verification reliable on slow Windows and source-checkout environments.

## What changed

- replace the publish workflow's slow `Expand-Archive` native smoke extraction with the supported .NET `System.IO.Compression.ZipFile` API
- reuse the shared fifteen-minute runtime restore timeout for source-checkout runtime archive rebuilds
- add workflow/runtime regressions and `0.3.45` release notes

## Verification

- focused release/runtime/content tests: `55/55`
- full `npm test`: `971/971`
- typecheck, build, architecture check, website lint/typecheck/build (`34` pages), root/site production audits, and `git diff --check` passed
- `npm outdated --long` reviewed; remaining drift is non-security and includes the coordinated Pi `0.84.2` pin

The exact committed head is `c1dada6b91639fe3299817e68465d78dfd8e78a3`. Clean Daytona proof is complete (`971/971`; 118,232,470-byte Linux tarball; SHA-256 `bbba52c1293846c0591ade3f629493bc00d4ede53c8fa8feca05929ea8d15a59`). The remaining gates are exact-head PR CI, merge, publication, and live release identity.
