### PR TITLE
Supersede 0.3.46 with repaired 0.3.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Workspace lab notebook for long-running or resumable research work.
 
 Use this file to track chronology, not release notes. Keep entries short, factual, and operational.
 
+### 2026-08-26 17:11 EDT — research-runtime-intake-0.3.47-emergency-hotfix
+
+- Objective: Supersede an unsafe `0.3.46` publication with the already qualified PR `#262` repair tree rather than leaving the immutable npm version as `latest`.
+- Incident: Publish run `33001506128` was canceled before publication during adversarial review, but a concurrent retry resumed it and published npm/GitHub `0.3.46` from superseded merge `6bbb6e8` while the repaired PR matrix was still running. Added an immediate GitHub release warning. npm deprecation was attempted but the local automation token cannot satisfy the package's interactive two-factor requirement.
+- Hotfix: Bumped the exact repaired tree to `0.3.47`; moved the corrected user-facing notes to `v0.3.47` and marked `v0.3.46` as superseded in repository and website release history.
+- Reused proof: Repair head `057fbfb` passed focused `112/112`, full `999/999`, typecheck/build/architecture/site checks, all audits, deterministic local package/consumer checks, disposable Daytona Node `25.9.0` full/package/runtime verification, and exact-head PR run `33009176960` including Windows native and all six OS/Node consumers. Merge `f2977bc` contains the identical repaired tree.
+- State: `unverified` for the version-only `0.3.47` package identity, successor PR CI, publication, and live latest-tag replacement. Next: qualify and merge the version/docs hotfix, then verify npm/GitHub `0.3.47`, installers, provenance, and actual installs.
+
 ### 2026-08-26 15:59 EDT — research-runtime-intake-0.3.46-release-blockers
 
 - Objective: Adversarially reconcile merged PR `#261` before `0.3.46` publication and stop any release whose package/runtime behavior was not actually exercised.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,7 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 ## Unreleased
 
-## v0.3.46 - 2026-08-26
+## v0.3.47 - 2026-08-26
 
 ### Research continuity
 
@@ -33,6 +33,12 @@ GitHub release notes are generated from the matching `## vX.Y.Z` section in this
 
 - Added exact source, published-upgrade, patch-plan transaction, package-tree, runtime-archive, executable OTLP handler, stdin-only proxy credential, GitHub clone proxy, installed-runtime OTLP behavior, GitHub document, Gemini ADC, Kimi credential, BTW provider, and unterminated-session regressions.
 - Runtime archives omit npm's pre-patch hidden lock metadata and verify its absence, so `npm ls` reads the committed exact lock instead of a stale nested Undici version.
+
+## v0.3.46 - 2026-08-26
+
+### Superseded release
+
+- Do not install `0.3.46`. Its canceled workflow was retried and published the superseded `6bbb6e8` tree with a pi-otel shutdown failure, explicit proxy/provider credentials in process arguments, and stale npm runtime metadata. Upgrade to `0.3.47` or later.
 
 ## v0.3.45 - 2026-08-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@companion-ai/feynman",
-      "version": "0.3.46",
+      "version": "0.3.47",
       "bundleDependencies": [
         "@companion-ai/alpha-hub",
         "@earendil-works/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-ai/feynman",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "description": "Research-first CLI agent built on Pi and alphaXiv",
   "license": "MIT",
   "type": "module",

--- a/website/src/content/docs/reference/releases.md
+++ b/website/src/content/docs/reference/releases.md
@@ -9,7 +9,7 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 ## Unreleased
 
-## v0.3.46 - 2026-08-26
+## v0.3.47 - 2026-08-26
 
 ### Research continuity
 
@@ -36,6 +36,12 @@ This page summarizes what changed in recent Feynman releases. GitHub releases us
 
 - Added exact source, published-upgrade, patch-plan transaction, package-tree, runtime-archive, executable OTLP handler, stdin-only proxy credential, GitHub clone proxy, installed-runtime OTLP behavior, GitHub document, Gemini ADC, Kimi credential, BTW provider, and unterminated-session regressions.
 - Runtime archives omit npm's pre-patch hidden lock metadata and verify its absence, so `npm ls` reads the committed exact lock instead of a stale nested Undici version.
+
+## v0.3.46 - 2026-08-26
+
+### Superseded release
+
+- Do not install `0.3.46`. Its canceled workflow was retried and published the superseded `6bbb6e8` tree with a pi-otel shutdown failure, explicit proxy/provider credentials in process arguments, and stale npm runtime metadata. Upgrade to `0.3.47` or later.
 
 ## v0.3.45 - 2026-08-26
 


### PR DESCRIPTION
## Emergency release hotfix

`0.3.46` was published from superseded merge `6bbb6e8` after its canceled workflow was retried. This version/docs hotfix publishes the already repaired and fully qualified PR #262 tree as `0.3.47`, moves the corrected release notes to that version, and marks `0.3.46` superseded.

## Exact-head proof

Exact head: `c95cf8ffd5bfcf5c5ad86ad2bfca48cb09d55032`

- repaired code head `057fbfb`: focused `112/112`, full `999/999`, typecheck/build/architecture/site checks, all audits, deterministic package/consumer verification, Daytona Node 25, PR run `33009176960`, Windows native installer, and all six OS/Node consumers
- version/docs head `c95cf8f`: focused release/runtime/docs `70/70`; full `999/999`; typecheck, architecture, website lint/typecheck/build, and root/runtime/site audits passed
- dry and real `0.3.47` packs matched: `118,263,422` bytes, `306,287,772` unpacked bytes, `29,209` entries; SHA-256 `4baef1fa5182ba66b12bf6a5fbd177d46ad7794d611e54f1800b8e00e878b879`
- clean `0.3.47` tarball consumer passed version/help, package/search, stale-Pi repair, package artifact, installed runtime/RPC, BTW ModelRuntime, OTLP routing, GitHub/web/proxy gates, LiteParse parse/search/screenshot, hidden-lock absence, consumer/runtime audits, and runtime `npm ls`
- local package runtime archive SHA-256: `746dfc609032e762e6147eb6709f6c75c44731e56738c9a3f9515d9a7865da15`

## Remaining gates

Require exact-head PR CI and clean-machine `0.3.47` package identity, then merge and verify npm/GitHub latest, provenance, assets, installers, and actual installs.
