### PR TITLE
Avoid duplicate runtime workspace validation during startup

### DIFF
--- a/scripts/patch-embedded-pi.mjs
+++ b/scripts/patch-embedded-pi.mjs
@@ -517,9 +517,7 @@ function linkBundledPackage(packageName) {
 		return false;
 	}
 }
-function ensureBundledPackageLinks(packageSpecs) {
-	if (!workspaceMatchesRuntime(packageSpecs)) return;
-
+function ensureBundledPackageLinks() {
 	const packageNames = listWorkspacePackageNames(workspaceRoot);
 	pruneStaleBundledPackageLinks(packageNames);
 	for (const packageName of packageNames) {
@@ -625,7 +623,7 @@ function ensurePackageWorkspaceUnlocked(heartbeat) {
 		reconcileRuntimeWorkspaceRestoreArtifacts(workspaceDir, {
 			workspaceIsHealthy: true,
 		});
-		ensureBundledPackageLinks(supportedPackageSpecs);
+		ensureBundledPackageLinks();
 		return;
 	}
 	let packagedRestore;
@@ -646,7 +644,7 @@ function ensurePackageWorkspaceUnlocked(heartbeat) {
 		);
 	}
 	if (packagedRestore.restored && workspaceMatchesRuntime(supportedPackageSpecs)) {
-		ensureBundledPackageLinks(supportedPackageSpecs);
+		ensureBundledPackageLinks();
 		return;
 	}
 	let installSeed = packagedRestore.installSeed;
@@ -663,7 +661,7 @@ function ensurePackageWorkspaceUnlocked(heartbeat) {
 			sourceRestore.restored &&
 			workspaceMatchesRuntime(supportedPackageSpecs)
 		) {
-			ensureBundledPackageLinks(supportedPackageSpecs);
+			ensureBundledPackageLinks();
 			return;
 		}
 		installSeed = sourceRestore.installSeed;
@@ -733,7 +731,7 @@ function ensurePackageWorkspaceUnlocked(heartbeat) {
 				"Feynman restored an incomplete bundled research runtime.",
 			);
 		}
-		ensureBundledPackageLinks(supportedPackageSpecs);
+		ensureBundledPackageLinks();
 	}
 }
 

--- a/tests/patch-embedded-pi.test.ts
+++ b/tests/patch-embedded-pi.test.ts
@@ -44,3 +44,66 @@ test("embedded Pi patch covers nested release-bundle copies before artifact veri
 		/\[\s*editorPath,\s*\.\.\.nestedEditorPaths,\s*workspaceEditorPath,\s*\.\.\.workspaceNestedEditorPaths,/,
 	);
 });
+
+function extractFunctionBody(source: string, signature: string): string {
+	const signatureStart = source.indexOf(signature);
+	assert.ok(signatureStart !== -1, `expected to find ${JSON.stringify(signature)}`);
+	const braceStart = source.indexOf("{", signatureStart);
+	assert.ok(braceStart !== -1, `expected a "{" after ${JSON.stringify(signature)}`);
+	let depth = 0;
+	for (let i = braceStart; i < source.length; i++) {
+		if (source[i] === "{") depth++;
+		else if (source[i] === "}") {
+			depth--;
+			if (depth === 0) return source.slice(braceStart, i + 1);
+		}
+	}
+	throw new Error(`unbalanced braces while scanning ${JSON.stringify(signature)}`);
+}
+
+test("ensureBundledPackageLinks does not repeat the runtime workspace integrity check", () => {
+	const source = readFileSync(resolve("scripts", "patch-embedded-pi.mjs"), "utf8");
+
+	const functionBody = extractFunctionBody(source, "function ensureBundledPackageLinks() {");
+	assert.doesNotMatch(functionBody, /workspaceMatchesRuntime/);
+
+	const allOccurrences = source.match(/ensureBundledPackageLinks\(/g) ?? [];
+	assert.equal(
+		allOccurrences.length,
+		5,
+		"expected exactly 1 definition + 4 call sites of ensureBundledPackageLinks; " +
+			"if you added or removed one, confirm it only runs after a successful " +
+			"workspaceMatchesRuntime() check and update this test",
+	);
+
+	const callSites = source.match(/(?<!function )ensureBundledPackageLinks\([^)]*\)/g) ?? [];
+	assert.equal(callSites.length, 4);
+	for (const callSite of callSites) {
+		assert.match(callSite, /^ensureBundledPackageLinks\(\)$/);
+	}
+
+	const workspaceUnlockedBody = extractFunctionBody(
+		source,
+		"function ensurePackageWorkspaceUnlocked(heartbeat) {",
+	);
+
+	assert.match(
+		workspaceUnlockedBody,
+		/if \(workspaceMatchesRuntime\(supportedPackageSpecs\)\) \{\s*reconcileRuntimeWorkspaceRestoreArtifacts\(workspaceDir, \{\s*workspaceIsHealthy: true,\s*\}\);\s*ensureBundledPackageLinks\(\);\s*return;\s*\}/,
+	);
+
+	assert.match(
+		workspaceUnlockedBody,
+		/if \(packagedRestore\.restored && workspaceMatchesRuntime\(supportedPackageSpecs\)\) \{\s*ensureBundledPackageLinks\(\);\s*return;\s*\}/,
+	);
+
+	assert.match(
+		workspaceUnlockedBody,
+		/if \(\s*sourceRestore\.restored &&\s*workspaceMatchesRuntime\(supportedPackageSpecs\)\s*\) \{\s*ensureBundledPackageLinks\(\);\s*return;\s*\}/,
+	);
+
+	assert.match(
+		workspaceUnlockedBody,
+		/if \(!workspaceMatchesRuntime\(supportedPackageSpecs\)\) \{\s*throw new Error\(\s*"Feynman restored an incomplete bundled research runtime\.",\s*\);\s*\}\s*ensureBundledPackageLinks\(\);/,
+	);
+});


### PR DESCRIPTION
On Windows, `feynman --version`, `--help`, and every other startup pay for a full workspace-integrity check (`workspaceMatchesRuntime` → tree hash/traversal) twice: once in `ensurePackageWorkspaceUnlocked` to confirm the workspace is healthy, and again inside `ensureBundledPackageLinks`, called immediately afterward.

Every current call site of `ensureBundledPackageLinks` is only reached after a successful `workspaceMatchesRuntime()` check, so the second validation is redundant.

This PR removes that internal check from `ensureBundledPackageLinks` (now parameterless); the invariant is enforced by the added regression test.

No integrity or recovery behavior is removed: the primary workspace validation, restore/recovery paths for an unhealthy workspace, completion-marker validation, and SHA-256 integrity checks remain unchanged.

## Windows benchmark

Measured locally on Windows x64 against the same checkout, with the filesystem cache warmed.

Baseline (`main`):

```text
patch-embedded-pi.mjs
20.435 s
20.598 s
22.398 s
20.607 s
21.708 s

mean: ~21.15 s
```

With this change:

```text
patch-embedded-pi.mjs
15.527 s
16.468 s
16.298 s
14.553 s
14.366 s

mean: ~15.44 s
```

This reduces patcher startup time by about 5.7 seconds (~27%) on this machine.

During the original diagnosis, a single `runtimeWorkspaceIntegrityIndexMatches()` pass measured about 6.1 seconds, which is consistent with the improvement from removing one redundant validation pass.

## Tests

Added a regression test in `tests/patch-embedded-pi.test.ts` covering the invariant that:

- `ensureBundledPackageLinks()` does not perform another `workspaceMatchesRuntime()` call;
- its current call sites remain accounted for;
- linking is only reached through paths that have already validated the runtime workspace.

Verified locally with:

```text
npm test
npm run typecheck
npm run build
git diff --check
```
