### PR TITLE
Copy real files when patching the bundled Undici proxy tree

### DIFF
--- a/scripts/lib/pi-undici-proxy-patch.mjs
+++ b/scripts/lib/pi-undici-proxy-patch.mjs
@@ -170,7 +170,13 @@ export function patchPiUndiciProxyTree(nodeModulesPath, fallbackPackagePath, req
 			const temporaryPath = `${nestedPackagePath}.feynman-proxy-${process.pid}`;
 			rmSync(temporaryPath, { recursive: true, force: true });
 			mkdirSync(dirname(temporaryPath), { recursive: true });
-			cpSync(safePackagePath, temporaryPath, { recursive: true });
+			// `safePackagePath` is often a link: the bundled workspace exposes
+			// packages through junctions, so copy the real files instead of
+			// recreating a link. Without `dereference`, `cpSync` reproduces the
+			// symlink, and creating one on Windows needs
+			// SeCreateSymbolicLinkPrivilege, which fails with EPERM in a normal
+			// non-elevated shell unless Developer Mode is on.
+			cpSync(safePackagePath, temporaryPath, { dereference: true, recursive: true });
 			rmSync(nestedPackagePath, { recursive: true, force: true });
 			renameSync(temporaryPath, nestedPackagePath);
 			changed = true;

--- a/tests/pi-undici-proxy-patch.test.ts
+++ b/tests/pi-undici-proxy-patch.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -176,6 +183,35 @@ test("Pi Undici patch replaces the nested package tree and is idempotent", () =>
 			.packages["node_modules/@earendil-works/pi-coding-agent/node_modules/undici"].version,
 		FEYNMAN_UNDICI_VERSION,
 	);
+	assert.equal(patchPiUndiciProxyTree(nodeModules), false);
+});
+
+test("Pi Undici patch materializes real files when the source tree is a link", () => {
+	const root = mkdtempSync(join(tmpdir(), "feynman-pi-undici-link-"));
+	const nodeModules = join(root, "node_modules");
+	const realPackage = join(root, "undici-real");
+	const safePackage = join(nodeModules, "undici");
+	const piRoot = join(nodeModules, "@earendil-works", "pi-coding-agent");
+	const nestedPackage = join(piRoot, "node_modules", "undici");
+	mkdirSync(realPackage, { recursive: true });
+	mkdirSync(nodeModules, { recursive: true });
+	mkdirSync(nestedPackage, { recursive: true });
+	writeFileSync(join(realPackage, "package.json"), JSON.stringify({ name: "undici", version: FEYNMAN_UNDICI_VERSION }));
+	writeFileSync(join(realPackage, "index.js"), "module.exports = { fixed: true };\n");
+	// The bundled workspace exposes packages through links, matching
+	// `linkBundledPackage` in scripts/patch-embedded-pi.mjs. Junctions need no
+	// privilege on Windows; the type argument is ignored elsewhere.
+	symlinkSync(realPackage, safePackage, process.platform === "win32" ? "junction" : "dir");
+	writeFileSync(join(nestedPackage, "package.json"), JSON.stringify({ name: "undici", version: upstreamVersion }));
+	writeFileSync(join(piRoot, "package.json"), piPackageJson());
+	writeFileSync(join(piRoot, "npm-shrinkwrap.json"), piShrinkwrap());
+
+	// Recreating the link here would need SeCreateSymbolicLinkPrivilege on
+	// Windows and fail with EPERM for a normal non-elevated user.
+	assert.equal(patchPiUndiciProxyTree(nodeModules), true);
+	assert.equal(lstatSync(nestedPackage).isSymbolicLink(), false);
+	assert.equal(JSON.parse(readFileSync(join(nestedPackage, "package.json"), "utf8")).version, FEYNMAN_UNDICI_VERSION);
+	assert.equal(readFileSync(join(nestedPackage, "index.js"), "utf8"), "module.exports = { fixed: true };\n");
 	assert.equal(patchPiUndiciProxyTree(nodeModules), false);
 });
 


### PR DESCRIPTION
## Summary

Fixes #275. On Windows, `cpSync` at `scripts/lib/pi-undici-proxy-patch.mjs:173` recreates the `undici` symlink (created by `linkBundledPackage`) instead of copying real files, because it defaults to `dereference: false`. Creating a `dir` symlink requires `SeCreateSymbolicLinkPrivilege`, which a non-elevated user does not hold — so every command fails with `EPERM` once any optional package is installed.

This change passes `dereference: true`, matching the precedent already in the repo at `scripts/verify-stale-pi-upgrade.mjs:460`.

## Changes

- `scripts/lib/pi-undici-proxy-patch.mjs` — add `dereference: true` to the `cpSync` call, with an explanatory comment.
- `tests/pi-undici-proxy-patch.test.ts` — regression test asserting the patched undici tree contains real files (not a symlink).

## Test coverage note

The regression test asserts `isSymbolicLink() === false`, which fails on **Linux too** (the unfixed code recreates the symlink there as well), so the existing ubuntu CI run catches regressions — no Windows-only test needed.

## Verification

- `npm run typecheck` — pass
- `npm run build` — pass
- Touched test file passes in full
- The full suite on Windows has 109 pre-existing failures at clean `main`; the failing set on this branch is identical (2 additional failures were confirmed flaky)

## CI status

- The ubuntu `npm test` workflow has **not run on this PR yet**: fork workflow runs await maintainer approval. Once approved, the ubuntu run is the one that exercises the new regression test.
- The Vercel check fails only because fork PRs need deploy authorization from a team member; it is not a build or test failure.
- GitGuardian security checks pass.

## Notes

This PR was prepared with AI assistance; the contributor verified the diff against the current source before opening.