### PR TITLE
fix: add bounded OpenAlex and arXiv HTML fallbacks

### DIFF
--- a/src/rank/paper-rank.ts
+++ b/src/rank/paper-rank.ts
@@ -37,6 +37,9 @@ export const DEFAULT_SCORE_WEIGHTS: Record<ScoreComponentKey, number> = {
 const OPENALEX_WORKS_URL = "https://api.openalex.org/works";
 const ARXIV_API_URL = "https://export.arxiv.org/api/query";
 const EXTERNAL_FETCH_TIMEOUT_MS = 15_000;
+const OPENALEX_MAX_RETRIES = 2;
+const OPENALEX_RETRY_BASE_MS = 250;
+const OPENALEX_RETRY_MAX_MS = 2_000;
 const OPENALEX_SELECT_FIELDS = [
 	"id",
 	"doi",
@@ -1188,6 +1191,32 @@ async function fetchWithTimeout(
 	}
 }
 
+function retryDelayMilliseconds(response: Response, attempt: number): number {
+	const retryAfter = response.headers.get("retry-after")?.trim();
+	if (retryAfter) {
+		const seconds = Number(retryAfter);
+		if (Number.isFinite(seconds) && seconds >= 0) return Math.min(OPENALEX_RETRY_MAX_MS, seconds * 1000);
+		const timestamp = Date.parse(retryAfter);
+		if (Number.isFinite(timestamp)) return Math.min(OPENALEX_RETRY_MAX_MS, Math.max(0, timestamp - Date.now()));
+	}
+	return Math.min(OPENALEX_RETRY_MAX_MS, OPENALEX_RETRY_BASE_MS * (2 ** attempt));
+}
+
+async function fetchOpenAlexWithRetry(
+	fetchImpl: typeof fetch,
+	input: string | URL,
+	init: RequestInit,
+	label: string,
+): Promise<Response> {
+	for (let attempt = 0; attempt <= OPENALEX_MAX_RETRIES; attempt += 1) {
+		const response = await fetchWithTimeout(fetchImpl, input, init, label);
+		const retryable = response.status === 429 || response.status >= 500;
+		if (!retryable || attempt === OPENALEX_MAX_RETRIES) return response;
+		await new Promise((resolve) => setTimeout(resolve, retryDelayMilliseconds(response, attempt)));
+	}
+	throw new Error(`${label} exhausted bounded retries`);
+}
+
 export async function fetchOpenAlexWorks(
 	topic: string,
 	limit: number,
@@ -1198,7 +1227,7 @@ export async function fetchOpenAlexWorks(
 	url.searchParams.set("per-page", String(limit));
 	url.searchParams.set("select", OPENALEX_SELECT_FIELDS);
 
-	const response = await fetchWithTimeout(fetchImpl, url, {
+	const response = await fetchOpenAlexWithRetry(fetchImpl, url, {
 		headers: {
 			Accept: "application/json",
 			"User-Agent": "Feynman PaperRank local research workflow",
@@ -1224,7 +1253,7 @@ export async function fetchOpenAlexWorksByIds(
 	url.searchParams.set("filter", `openalex:${shortIds.join("|")}`);
 	url.searchParams.set("per-page", String(shortIds.length));
 	url.searchParams.set("select", OPENALEX_SELECT_FIELDS);
-	const response = await fetchWithTimeout(fetchImpl, url, {
+	const response = await fetchOpenAlexWithRetry(fetchImpl, url, {
 		headers: {
 			Accept: "application/json",
 			"User-Agent": "Feynman PaperRank citation expansion workflow",
@@ -1252,7 +1281,7 @@ export async function fetchOpenAlexWorksCiting(
 	url.searchParams.set("per-page", String(limit));
 	url.searchParams.set("sort", "cited_by_count:desc");
 	url.searchParams.set("select", OPENALEX_SELECT_FIELDS);
-	const response = await fetchWithTimeout(fetchImpl, url, {
+	const response = await fetchOpenAlexWithRetry(fetchImpl, url, {
 		headers: {
 			Accept: "application/json",
 			"User-Agent": "Feynman PaperRank citation expansion workflow",
@@ -1598,7 +1627,11 @@ function safeExternalUrl(value: string | null | undefined): string | undefined {
 	}
 }
 
-export function buildFullTextAccessPlan(paper: PaperRecord, generatedAt?: string): FullTextAccessPlan {
+export function buildFullTextAccessPlan(
+	paper: PaperRecord,
+	generatedAt?: string,
+	preferredCandidate?: string,
+): FullTextAccessPlan {
 	const candidates: FullTextAccessCandidate[] = [];
 	const seen = new Set<string>();
 	const add = (candidate: FullTextAccessCandidate) => {
@@ -1617,6 +1650,16 @@ export function buildFullTextAccessPlan(paper: PaperRecord, generatedAt?: string
 			isOpenAccess: true,
 			canFetch: true,
 			note: "Feynman can fetch arXiv paper text through the bundled alphaXiv client when available.",
+		});
+		add({
+			source: "arXiv",
+			kind: "api_full_text",
+			label: "arXiv HTML",
+			identifier: paper.arxivId,
+			url: `https://arxiv.org/html/${paper.arxivId}`,
+			isOpenAccess: true,
+			canFetch: true,
+			note: "Official arXiv HTML is used as a bounded full-text fallback when the primary reader is unavailable.",
 		});
 		add({
 			source: "arXiv",
@@ -1722,6 +1765,9 @@ export function buildFullTextAccessPlan(paper: PaperRecord, generatedAt?: string
 					? "candidates_found"
 					: "no_candidate";
 	const bestCandidate =
+		(preferredCandidate
+			? candidates.find((candidate) => candidate.canFetch && (candidate.label === preferredCandidate || candidate.source === preferredCandidate))
+			: undefined) ??
 		candidates.find((candidate) => candidate.canFetch) ??
 		candidates.find((candidate) => candidate.isOpenAccess) ??
 		candidates[0];
@@ -3991,6 +4037,48 @@ export async function fetchAlphaPaperContent(paper: PaperRecord): Promise<PaperC
 	}
 }
 
+function htmlToText(html: string): string | undefined {
+	const text = html
+		.replace(/<!--[\s\S]*?-->/g, " ")
+		.replace(/<(script|style|noscript|template)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")
+		.replace(/<\/?(?:address|article|br|dd|div|dl|dt|figcaption|figure|footer|h[1-6]|header|hr|li|main|nav|ol|p|pre|section|table|tbody|td|th|thead|tr|ul)\b[^>]*>/gi, "\n")
+		.replace(/<[^>]+>/g, " ")
+		.replace(/&(?:amp|lt|gt|quot|apos|nbsp|#39|#x[0-9a-f]+|#[0-9]+);/gi, (match) => {
+			const entity = match.slice(1, -1).toLowerCase();
+			if (entity === "amp") return "&";
+			if (entity === "lt") return "<";
+			if (entity === "gt") return ">";
+			if (entity === "quot") return '"';
+			if (entity === "apos" || entity === "#39") return "'";
+			if (entity === "nbsp") return " ";
+			const codePoint = entity.startsWith("#x")
+				? Number.parseInt(entity.slice(2), 16)
+				: Number.parseInt(entity.slice(1), 10);
+			return Number.isInteger(codePoint) && isXmlCharacter(codePoint) ? String.fromCodePoint(codePoint) : match;
+		})
+		.replace(/[ \t]+/g, " ")
+		.replace(/\n\s+/g, "\n")
+		.replace(/\n{3,}/g, "\n\n");
+	return cleanString(text);
+}
+
+export async function fetchArxivPaperContent(
+	paper: PaperRecord,
+	fetchImpl: typeof fetch = fetch,
+): Promise<PaperContentFetchResult | undefined> {
+	if (!paper.arxivId) return undefined;
+	const url = `https://arxiv.org/html/${paper.arxivId}`;
+	const response = await fetchWithTimeout(fetchImpl, url, {
+		headers: {
+			Accept: "text/html",
+			"User-Agent": "Feynman arXiv HTML resolver",
+		},
+	}, "arXiv HTML full-text request");
+	if (!response.ok) return undefined;
+	const content = htmlToText(await response.text());
+	return content ? { content, source: "arXiv HTML" } : undefined;
+}
+
 export async function fetchEuropePmcPaperContent(
 	paper: PaperRecord,
 	fetchImpl: typeof fetch = fetch,
@@ -4078,6 +4166,12 @@ function createDefaultPaperContentFetcher(fetchImpl: typeof fetch = fetch): Pape
 			} catch (error) {
 				errors.push(artifactErrorMessage("alphaXiv", error));
 			}
+			try {
+				const result = await fetchArxivPaperContent(paper, fetchImpl);
+				if (extractPaperContentText(result?.content)) return result;
+			} catch (error) {
+				errors.push(artifactErrorMessage("arXiv HTML", error));
+			}
 		}
 		if (paper.pmcid || paper.pmid || paper.doi) {
 			try {
@@ -4145,7 +4239,7 @@ export async function enrichPapersWithFullText(
 			};
 			updates.set(paper.paperId, {
 				...enrichedPaper,
-				fullTextAccess: buildFullTextAccessPlan(enrichedPaper, options.fetchedAt),
+				fullTextAccess: buildFullTextAccessPlan(enrichedPaper, options.fetchedAt, source),
 			});
 		} catch (error) {
 			const erroredPaper: PaperRecord = {
@@ -4369,7 +4463,7 @@ export async function fetchOpenAlexWorkByIdentifier(
 	}
 	url.searchParams.set("per-page", arxivId || isTitleSearchIdentifier(normalized) ? "10" : "1");
 	url.searchParams.set("select", OPENALEX_SELECT_FIELDS);
-	const response = await fetchWithTimeout(fetchImpl, url, {
+	const response = await fetchOpenAlexWithRetry(fetchImpl, url, {
 		headers: {
 			Accept: "application/json",
 			"User-Agent": "Feynman paper access resolver",
@@ -4442,7 +4536,7 @@ export async function resolvePaperAccess(options: PaperAccessOptions): Promise<P
 					fullTextSections: extractFullTextSections(text, sourceLabel),
 					provenance: appendProvenance(paper.provenance, sourceLabel, ["fullText", "fullTextSections"]),
 				};
-				paper = { ...paper, fullTextAccess: buildFullTextAccessPlan(paper, generatedAt) };
+				paper = { ...paper, fullTextAccess: buildFullTextAccessPlan(paper, generatedAt, sourceLabel) };
 				fullText = {
 					requested: true,
 					status: "available",

--- a/tests/paper-rank.test.ts
+++ b/tests/paper-rank.test.ts
@@ -18,6 +18,7 @@ import {
 	extractEvidenceSpans,
 	extractFullTextSections,
 	extractPaperContentText,
+	fetchArxivPaperContent,
 	fetchEuropePmcPaperContent,
 	fetchOpenAlexWorks,
 	generateFieldMap,
@@ -40,6 +41,7 @@ import {
 	runPaperRank,
 	scorePapers,
 	slugifyTopic,
+	type PaperRecord,
 } from "../src/rank/paper-rank.js";
 
 const fixturePath = resolve(process.cwd(), "tests", "fixtures", "openalex-rank.json");
@@ -102,6 +104,23 @@ test("fetchOpenAlexWorks bounds provider calls with an abort signal", async () =
 	assert.equal(result.works.length, 0);
 	assert.ok(signal);
 	assert.equal(signal.aborted, false);
+});
+
+test("fetchOpenAlexWorks retries a rate-limited provider once with bounded backoff", async () => {
+	let calls = 0;
+	const fetchImpl = async () => {
+		calls += 1;
+		if (calls === 1) return new Response("busy", { status: 429, headers: { "retry-after": "0" } });
+		return new Response(JSON.stringify({ results: [], meta: { count: 0 } }), {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		});
+	};
+
+	const result = await fetchOpenAlexWorks("rate limited topic", 1, fetchImpl as typeof fetch);
+
+	assert.equal(result.works.length, 0);
+	assert.equal(calls, 2);
 });
 
 test("PaperRank slug and limit parsing are stable", () => {
@@ -183,6 +202,19 @@ test("extractPaperContentText normalizes common alphaXiv content payload shapes"
 	assert.equal(extractPaperContentText(["Intro", { text: "Methods" }]), "Intro\nMethods");
 });
 
+test("fetchArxivPaperContent converts official HTML into bounded text", async () => {
+	const fetchImpl = (async () => new Response(
+		"<html><head><style>.x{}</style></head><body><h1>Abstract</h1><p>We test &amp; compare.</p><script>secret()</script><h2>Methods</h2><p>Finite probe.</p></body></html>",
+		{ status: 200, headers: { "content-type": "text/html" } },
+	)) as typeof fetch;
+	const result = await fetchArxivPaperContent({ arxivId: "2609.04506" } as PaperRecord, fetchImpl);
+
+	assert.equal(result?.source, "arXiv HTML");
+	assert.match(extractPaperContentText(result?.content) ?? "", /Abstract\nWe test & compare/);
+	assert.match(extractPaperContentText(result?.content) ?? "", /Methods\nFinite probe/);
+	assert.doesNotMatch(extractPaperContentText(result?.content) ?? "", /secret/);
+});
+
 test("extractFullTextSections preserves canonical section offsets", () => {
 	const text = [
 		"# Methods",
@@ -257,6 +289,8 @@ test("buildFullTextAccessPlan records legal source-specific candidates", () => {
 
 	assert.equal(access.status, "candidates_found");
 	assert.ok(access.candidates.some((candidate) => candidate.source === "alphaXiv" && candidate.canFetch));
+	assert.ok(access.candidates.some((candidate) => candidate.label === "arXiv HTML" && candidate.canFetch));
+	assert.equal(buildFullTextAccessPlan(paper, undefined, "arXiv HTML").bestCandidate?.label, "arXiv HTML");
 	assert.ok(access.candidates.some((candidate) => candidate.source === "Europe PMC" && candidate.kind === "full_text_xml" && candidate.canFetch));
 	assert.ok(access.candidates.some((candidate) => candidate.source === "DOI"));
 	assert.ok(access.limits.some((limit) => /does not bypass paywalls/i.test(limit)));


### PR DESCRIPTION
## Summary\n\n- add bounded retry/backoff for transient OpenAlex 429/5xx responses\n- honor Retry-After with a capped delay\n- fall back to official arXiv HTML when PDF/full text is unavailable\n- sanitize HTML to usable research text and select preferred full-text candidates explicitly\n- add focused regression coverage\n\n## Validation\n\n- TAP version 13
# Subtest: abstractFromInvertedIndex reconstructs OpenAlex abstracts
ok 1 - abstractFromInvertedIndex reconstructs OpenAlex abstracts
  ---
  duration_ms: 0.561208
  type: 'test'
  ...
# Subtest: fetchOpenAlexWorks bounds provider calls with an abort signal
ok 2 - fetchOpenAlexWorks bounds provider calls with an abort signal
  ---
  duration_ms: 8.071958
  type: 'test'
  ...
# Subtest: fetchOpenAlexWorks retries a rate-limited provider once with bounded backoff
ok 3 - fetchOpenAlexWorks retries a rate-limited provider once with bounded backoff
  ---
  duration_ms: 2.869834
  type: 'test'
  ...
# Subtest: PaperRank slug and limit parsing are stable
ok 4 - PaperRank slug and limit parsing are stable
  ---
  duration_ms: 0.457334
  type: 'test'
  ...
# Subtest: computePageRank gives cited papers more local graph prestige
ok 5 - computePageRank gives cited papers more local graph prestige
  ---
  duration_ms: 0.2395
  type: 'test'
  ...
# Subtest: extractEvidenceSpans returns marker offsets and surrounding source text
ok 6 - extractEvidenceSpans returns marker offsets and surrounding source text
  ---
  duration_ms: 0.357125
  type: 'test'
  ...
# Subtest: extractEvidenceSpans requires marker boundaries
ok 7 - extractEvidenceSpans requires marker boundaries
  ---
  duration_ms: 0.143875
  type: 'test'
  ...
# Subtest: extractPaperContentText normalizes common alphaXiv content payload shapes
ok 8 - extractPaperContentText normalizes common alphaXiv content payload shapes
  ---
  duration_ms: 0.070209
  type: 'test'
  ...
# Subtest: fetchArxivPaperContent converts official HTML into bounded text
ok 9 - fetchArxivPaperContent converts official HTML into bounded text
  ---
  duration_ms: 1.037958
  type: 'test'
  ...
# Subtest: extractFullTextSections preserves canonical section offsets
ok 10 - extractFullTextSections preserves canonical section offsets
  ---
  duration_ms: 0.548917
  type: 'test'
  ...
# Subtest: evaluatePaperRubric answers checklist items from extracted sections
ok 11 - evaluatePaperRubric answers checklist items from extracted sections
  ---
  duration_ms: 0.361083
  type: 'test'
  ...
# Subtest: buildFullTextAccessPlan records legal source-specific candidates
ok 12 - buildFullTextAccessPlan records legal source-specific candidates
  ---
  duration_ms: 1.325709
  type: 'test'
  ...
# Subtest: normalizeOpenAlexWorks keeps repository PDFs from all OpenAlex locations
ok 13 - normalizeOpenAlexWorks keeps repository PDFs from all OpenAlex locations
  ---
  duration_ms: 0.168208
  type: 'test'
  ...
# Subtest: normalizeOpenAlexWorks drops non-http provider URLs and canonicalizes DOI links
ok 14 - normalizeOpenAlexWorks drops non-http provider URLs and canonicalizes DOI links
  ---
  duration_ms: 0.154083
  type: 'test'
  ...
# Subtest: resolvePaperAccess writes Markdown-safe provider titles and links
ok 15 - resolvePaperAccess writes Markdown-safe provider titles and links
  ---
  duration_ms: 2.157542
  type: 'test'
  ...
# Subtest: normalizeOpenAlexWorks extracts arXiv ids from secondary OpenAlex access locations
ok 16 - normalizeOpenAlexWorks extracts arXiv ids from secondary OpenAlex access locations
  ---
  duration_ms: 0.109958
  type: 'test'
  ...
# Subtest: fetchEuropePmcPaperContent discovers PMCID from DOI before fetching XML
ok 17 - fetchEuropePmcPaperContent discovers PMCID from DOI before fetching XML
  ---
  duration_ms: 0.896833
  type: 'test'
  ...
# Subtest: runPaperRank full-text enrichment discovers Europe PMC content from DOI-only OpenAlex papers
ok 18 - runPaperRank full-text enrichment discovers Europe PMC content from DOI-only OpenAlex papers
  ---
  duration_ms: 11.351916
  type: 'test'
  ...
# Subtest: scorePapers separates impact, graph, methodology, and reproducibility
ok 19 - scorePapers separates impact, graph, methodology, and reproducibility
  ---
  duration_ms: 0.652542
  type: 'test'
  ...
# Subtest: scorePapers excludes graph prestige when local citation edges are absent
ok 20 - scorePapers excludes graph prestige when local citation edges are absent
  ---
  duration_ms: 0.655
  type: 'test'
  ...
# Subtest: expandCitationNeighborhood adds outgoing references and incoming citations
ok 21 - expandCitationNeighborhood adds outgoing references and incoming citations
  ---
  duration_ms: 0.526333
  type: 'test'
  ...
# Subtest: generatePaperCritiques creates span-grounded review questions
ok 22 - generatePaperCritiques creates span-grounded review questions
  ---
  duration_ms: 0.900208
  type: 'test'
  ...
# Subtest: generateFieldMap identifies clusters and paper roles
ok 23 - generateFieldMap identifies clusters and paper roles
  ---
  duration_ms: 0.522875
  type: 'test'
  ...
# Subtest: generateRankSensitivity records rank movement across weighting profiles
ok 24 - generateRankSensitivity records rank movement across weighting profiles
  ---
  duration_ms: 1.164708
  type: 'test'
  ...
# Subtest: generateScoreCalibration evaluates researcher read-order preferences
ok 25 - generateScoreCalibration evaluates researcher read-order preferences
  ---
  duration_ms: 0.929292
  type: 'test'
  ...
# Subtest: generateReproductionEvidenceLedger records completed reproduction notes separately
ok 26 - generateReproductionEvidenceLedger records completed reproduction notes separately
  ---
  duration_ms: 0.627875
  type: 'test'
  ...
# Subtest: buildModelSynthesisPacket creates a bounded auditable model handoff
ok 27 - buildModelSynthesisPacket creates a bounded auditable model handoff
  ---
  duration_ms: 1.332708
  type: 'test'
  ...
# Subtest: resolvePaperAccess writes bounded paper-access artifacts
ok 28 - resolvePaperAccess writes bounded paper-access artifacts
  ---
  duration_ms: 1.137917
  type: 'test'
  ...
# Subtest: resolvePaperAccess escapes provider full-text source labels in Markdown reports
ok 29 - resolvePaperAccess escapes provider full-text source labels in Markdown reports
  ---
  duration_ms: 0.681084
  type: 'test'
  ...
# Subtest: enrichPapersWithFullText redacts fetcher failure messages
ok 30 - enrichPapersWithFullText redacts fetcher failure messages
  ---
  duration_ms: 0.347375
  type: 'test'
  ...
# Subtest: resolvePaperAccess rejects unrelated OpenAlex hits for arXiv identifiers
ok 31 - resolvePaperAccess rejects unrelated OpenAlex hits for arXiv identifiers
  ---
  duration_ms: 1.867541
  type: 'test'
  ...
# Subtest: resolvePaperAccess enriches arXiv fallback records from the arXiv API
ok 32 - resolvePaperAccess enriches arXiv fallback records from the arXiv API
  ---
  duration_ms: 1.688042
  type: 'test'
  ...
# Subtest: resolvePaperAccess accepts OpenAlex hits whose arXiv id is only in secondary locations
ok 33 - resolvePaperAccess accepts OpenAlex hits whose arXiv id is only in secondary locations
  ---
  duration_ms: 0.770292
  type: 'test'
  ...
# Subtest: resolvePaperAccess checks multiple OpenAlex candidates for arXiv identifiers
ok 34 - resolvePaperAccess checks multiple OpenAlex candidates for arXiv identifiers
  ---
  duration_ms: 0.525542
  type: 'test'
  ...
# Subtest: resolvePaperAccess treats title-like arXiv-shaped numbers as title search text
ok 35 - resolvePaperAccess treats title-like arXiv-shaped numbers as title search text
  ---
  duration_ms: 0.462083
  type: 'test'
  ...
# Subtest: resolvePaperAccess checks multiple OpenAlex candidates for title searches
ok 36 - resolvePaperAccess checks multiple OpenAlex candidates for title searches
  ---
  duration_ms: 0.895791
  type: 'test'
  ...
# Subtest: resolvePaperAccess rejects unrelated OpenAlex title search results
ok 37 - resolvePaperAccess rejects unrelated OpenAlex title search results
  ---
  duration_ms: 0.471541
  type: 'test'
  ...
# Subtest: resolvePaperAccess treats title-like DOI substrings as title search text
ok 38 - resolvePaperAccess treats title-like DOI substrings as title search text
  ---
  duration_ms: 0.687916
  type: 'test'
  ...
# Subtest: resolvePaperAccess keeps explicit DOI inputs on the DOI lookup path
ok 39 - resolvePaperAccess keeps explicit DOI inputs on the DOI lookup path
  ---
  duration_ms: 0.734875
  type: 'test'
  ...
# Subtest: resolvePaperAccess keeps explicit OpenAlex IDs on the OpenAlex lookup path
ok 40 - resolvePaperAccess keeps explicit OpenAlex IDs on the OpenAlex lookup path
  ---
  duration_ms: 0.5
  type: 'test'
  ...
# Subtest: resolvePaperAccess keeps explicit PMID inputs on the PMID lookup path
ok 41 - resolvePaperAccess keeps explicit PMID inputs on the PMID lookup path
  ---
  duration_ms: 0.539375
  type: 'test'
  ...
# Subtest: resolvePaperAccess keeps explicit PMCID inputs on the PMCID lookup path
ok 42 - resolvePaperAccess keeps explicit PMCID inputs on the PMCID lookup path
  ---
  duration_ms: 0.410416
  type: 'test'
  ...
# Subtest: runPaperRank writes durable report, data, graph, and provenance artifacts
ok 43 - runPaperRank writes durable report, data, graph, and provenance artifacts
  ---
  duration_ms: 9.19375
  type: 'test'
  ...
# Subtest: runPaperRank writes Markdown-safe topic headings and shell snippets
ok 44 - runPaperRank writes Markdown-safe topic headings and shell snippets
  ---
  duration_ms: 3.451
  type: 'test'
  ...
# Subtest: runPaperRank escapes script-breaking graph artifact data
ok 45 - runPaperRank escapes script-breaking graph artifact data
  ---
  duration_ms: 2.103
  type: 'test'
  ...
# Subtest: runPaperRank redacts model synthesis failure messages from artifacts
ok 46 - runPaperRank redacts model synthesis failure messages from artifacts
  ---
  duration_ms: 2.175875
  type: 'test'
  ...
# Subtest: feynman rank works end to end through the CLI with a fixture source
ok 47 - feynman rank works end to end through the CLI with a fixture source
  ---
  duration_ms: 1708.422625
  type: 'test'
  ...
# Subtest: feynman rank default output is concise and decision-first
ok 48 - feynman rank default output is concise and decision-first
  ---
  duration_ms: 961.6535
  type: 'test'
  ...
# Subtest: feynman rank writes default outputs under --cwd
ok 49 - feynman rank writes default outputs under --cwd
  ---
  duration_ms: 1631.02725
  type: 'test'
  ...
# Subtest: feynman paper works end to end through the CLI with a fixture source
ok 50 - feynman paper works end to end through the CLI with a fixture source
  ---
  duration_ms: 1587.384083
  type: 'test'
  ...
# Subtest: feynman paper default output names the best access route
ok 51 - feynman paper default output names the best access route
  ---
  duration_ms: 965.927875
  type: 'test'
  ...
# Subtest: feynman paper writes default outputs under --cwd
ok 52 - feynman paper writes default outputs under --cwd
  ---
  duration_ms: 1700.056875
  type: 'test'
  ...
# Subtest: feynman rank accepts a preference file through the CLI
ok 53 - feynman rank accepts a preference file through the CLI
  ---
  duration_ms: 1703.431166
  type: 'test'
  ...
# Subtest: feynman rank accepts reproduction notes through the CLI
ok 54 - feynman rank accepts reproduction notes through the CLI
  ---
  duration_ms: 1992.54175
  type: 'test'
  ...
1..54
# tests 54
# suites 0
# pass 54
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 12411.798834 — 54 passed\n- 
> @advaitpaliwal/feynman@0.3.49 typecheck
> tsc --noEmit && npm run typecheck:workbench-web


> @advaitpaliwal/feynman@0.3.49 typecheck:workbench-web
> tsc -p workbench-web/tsconfig.json --noEmit — passed\n-  — passed\n\nThe full suite is not claimed green because unrelated provider/model environment tests require external credentials or native runtime assumptions.