### PR TITLE
Retry esbuild tree removals with backoff for transient EPERM

### DIFF
--- a/scripts/lib/pi-esbuild-package-patch.mjs
+++ b/scripts/lib/pi-esbuild-package-patch.mjs
@@ -3,6 +3,7 @@ import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSyn
 import { createRequire } from "node:module";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
+import { removeTemporaryTree } from "./temporary-tree-cleanup.mjs";
 
 // Exact registry esbuild 0.28.2 wrapper/manifest; 23 vendor binary hashes plus
 // three WASM-platform binary hashes from integrity-verified platform tarballs.
@@ -482,7 +483,7 @@ export function patchPiEsbuildPackageTree(nodeModulesPath, sourcePackagePath = r
 		changed = true;
 	}
 	for (const target of targets) if (!treeMatches(target, files)) { replacePortableTree(target, files); changed = true; }
-	for (const dir of removals) { rmSync(dir, { recursive: true }); changed = true; }
+	for (const dir of removals) { removeTemporaryTree(dir); changed = true; }
 	for (const [path, source] of metadata) if (readFileSync(path, "utf8") !== source) { writeFileSync(path, source); changed = true; }
 	return changed;
 }


### PR DESCRIPTION
## Summary

Fixes #281. On Windows, `rmSync` at `scripts/lib/pi-esbuild-package-patch.mjs:485` races Defender's handle on a freshly written 11.6 MB `esbuild.exe`, throwing intermittent `EPERM` during `npm test` / `prepack`. The repo already solved this in `scripts/lib/temporary-tree-cleanup.mjs` (`removeTemporaryTree`, which retries `EPERM` and other removal codes with exponential backoff); this call site just never used it.

## Changes

- `scripts/lib/pi-esbuild-package-patch.mjs` — replace the bare `rmSync(dir, { recursive: true })` with `removeTemporaryTree(dir)` (adds `force: true` plus bounded retries with exponential backoff).

## Test note

No new call-site test: the helper is already tested in `tests/temporary-tree-cleanup.test.ts` (injects a failing `remove` to simulate `EPERM`). Asserting retry behavior at this call site would require widening `patchPiEsbuildPackageTree`'s API purely for testability — happy to add that plumbing if preferred.

## Verification

- `npm run typecheck` — pass
- Touched test file (`tests/pi-esbuild-package-patch.test.ts`) passes in full for the covered behavior; the full file on Windows has 5 failures, all pre-existing non-elevated symlink `EPERM` at fixture setup (identical on clean `main`)
- The full suite on Windows has 109 pre-existing failures at clean `main`; this change adds none

## CI status

- The ubuntu `npm test` workflow has **not run on this PR yet**: fork workflow runs await maintainer approval.
- The Vercel check fails only because fork PRs need deploy authorization from a team member; it is not a build or test failure.
- GitGuardian security checks pass.

## Notes

This PR was prepared with AI assistance; the contributor verified the diff against the current source before opening.